### PR TITLE
feat: implement taste job queue and deduplication logic in function_app

### DIFF
--- a/PluckIt.Processor/function_app.py
+++ b/PluckIt.Processor/function_app.py
@@ -34,14 +34,35 @@ Endpoints:
 
 import asyncio
 import base64
+import hashlib
 import io
 import json
 import logging
 import os
+import random
+import time
 import uuid
 from datetime import datetime, timedelta, timezone
 from importlib import import_module
 from typing import Any, Optional, Annotated
+
+
+def _get_int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        logger = logging.getLogger(__name__)
+        logger.warning("Invalid value for %s, using default %s", name, default)
+        return default
+
+
+def _get_float_env(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        logger = logging.getLogger(__name__)
+        logger.warning("Invalid value for %s, using default %s", name, default)
+        return default
 
 # Point rembg at the bundled model directory so it never downloads at runtime.
 os.environ.setdefault(
@@ -79,6 +100,28 @@ _ERR_NO_IMAGE_PROVIDED = "No image provided."
 _ERR_MOOD_NOT_FOUND = "Mood not found."
 
 background_tasks = set()
+
+_TASTE_JOB_QUEUE: asyncio.Queue[dict[str, Any]] | None = None
+# In-memory dedupe guards are process-local only (lost on cold start/restart).
+# Duplicates may still happen across instances/restarts, so this mechanism
+# assumes downstream side-effect handlers (for example, _update_user_profile)
+# are idempotent or upsert-safe. If stronger guarantees are needed, replace
+# _TASTE_JOB_IN_FLIGHT/_TASTE_JOB_COMPLETED with a persistent dedupe store
+# such as Redis or Cosmos DB.
+_TASTE_JOB_IN_FLIGHT: dict[str, float] = {}
+_TASTE_JOB_COMPLETED: dict[str, float] = {}
+_TASTE_JOB_PERSISTED: list[dict[str, Any]] = []
+_TASTE_WORKER_TASK: asyncio.Task[Any] | None = None
+
+_TASTE_JOB_DEDUPE_TTL_SECONDS = _get_int_env("TASTE_JOB_DEDUPE_TTL_SECONDS", 180)
+_TASTE_JOB_COMPLETED_TTL_SECONDS = _get_int_env("TASTE_JOB_COMPLETED_TTL_SECONDS", 3600)
+_TASTE_JOB_MAX_RETRIES = 3
+_TASTE_JOB_BASE_BACKOFF_SECONDS = _get_float_env("TASTE_JOB_BASE_BACKOFF_SECONDS", 0.75)
+_TASTE_JOB_MAX_BACKOFF_SECONDS = _get_float_env("TASTE_JOB_MAX_BACKOFF_SECONDS", 6.0)
+_TASTE_JOB_JITTER_SECONDS = _get_float_env("TASTE_JOB_JITTER_SECONDS", 0.2)
+_TASTE_JOB_PROFILE_UPDATE_MAX_RETRIES = 2
+
+_TASTE_JOB_QUEUE_MAX_SIZE = _get_int_env("TASTE_JOB_QUEUE_MAX_SIZE", 1024)
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +167,7 @@ async def _global_exception_handler(request: Request, exc: Exception) -> JSONRes
 async def _startup_log() -> None:
     env = os.getenv("AZURE_FUNCTIONS_ENVIRONMENT", "Production")
     logger.info("PluckIt Processor started — environment=%s", env)
+    _ensure_taste_worker_running()
 
 
 # ── Azure Functions ASGI app (handles HTTP via FastAPI + non-HTTP triggers) ──
@@ -132,6 +176,221 @@ app = func.AsgiFunctionApp(app=fastapi_app, http_auth_level=func.AuthLevel.ANONY
 
 
 # ── Helper utilities ─────────────────────────────────────────────────────────
+
+def _get_taste_job_queue() -> asyncio.Queue[dict[str, Any]]:
+    global _TASTE_JOB_QUEUE
+    if _TASTE_JOB_QUEUE is None:
+        _TASTE_JOB_QUEUE = asyncio.Queue(maxsize=_TASTE_JOB_QUEUE_MAX_SIZE)
+    return _TASTE_JOB_QUEUE
+
+
+def _taste_job_id(user_id: str, item_id: str, image_url: str, gallery_image_index: int | None) -> str:
+    return hashlib.sha256(
+        f"{user_id}:{item_id}:{image_url}:{gallery_image_index if gallery_image_index is not None else '-'}".encode("utf-8")
+    ).hexdigest()
+
+
+def _purge_taste_job_guards(now: float) -> None:
+    for key, exp in _TASTE_JOB_IN_FLIGHT.copy().items():
+        if exp <= now:
+            _TASTE_JOB_IN_FLIGHT.pop(key, None)
+    for key, exp in _TASTE_JOB_COMPLETED.copy().items():
+        if exp <= now:
+            _TASTE_JOB_COMPLETED.pop(key, None)
+
+
+def _is_taste_job_duplicate(job_id: str, now: float) -> bool:
+    _purge_taste_job_guards(now)
+    if _TASTE_JOB_IN_FLIGHT.get(job_id, 0.0) > now:
+        return True
+    if _TASTE_JOB_COMPLETED.get(job_id, 0.0) > now:
+        return True
+    _TASTE_JOB_IN_FLIGHT[job_id] = now + _TASTE_JOB_DEDUPE_TTL_SECONDS
+    return False
+
+
+def _mark_taste_job_completed(job_id: str, now: float) -> None:
+    _TASTE_JOB_IN_FLIGHT.pop(job_id, None)
+    _TASTE_JOB_COMPLETED[job_id] = now + _TASTE_JOB_COMPLETED_TTL_SECONDS
+
+
+def _persist_taste_job(job: dict[str, Any]) -> None:
+    # Hook for durable persistence (eg: Cosmos/Redis queue table) when shutdown
+    # or cancellation occurs before a job can be processed.
+    _TASTE_JOB_PERSISTED.append(job)
+    # Current implementation keeps jobs in-memory for in-process recovery.
+    # Replace with durable storage for guaranteed cross-process replay.
+    logger.warning(
+        "Persisting pending taste-profile job for recovery: %s (item %s, user %s)",
+        job.get("job_id"),
+        job.get("item_id"),
+        job.get("user_id"),
+    )
+
+
+def _drain_taste_job_queue_for_shutdown(queue: asyncio.Queue[dict[str, Any]]) -> None:
+    while True:
+        try:
+            job = queue.get_nowait()
+        except asyncio.QueueEmpty:
+            break
+        try:
+            _persist_taste_job(job)
+        finally:
+            queue.task_done()
+
+
+def _ensure_taste_worker_running() -> None:
+    global _TASTE_WORKER_TASK
+    if _TASTE_WORKER_TASK is not None and not _TASTE_WORKER_TASK.done():
+        return
+
+    _TASTE_WORKER_TASK = asyncio.create_task(_taste_job_worker())
+    background_tasks.add(_TASTE_WORKER_TASK)
+    _TASTE_WORKER_TASK.add_done_callback(background_tasks.discard)
+
+
+def _maybe_enqueue_taste_job(
+    user_id: str,
+    item_id: str,
+    image_url: str,
+    gallery_image_index: int | None,
+    signal: str,
+) -> bool:
+    if signal != "up":
+        return False
+    if not image_url:
+        return False
+
+    job_id = _taste_job_id(user_id, item_id, image_url, gallery_image_index)
+    now = time.monotonic()
+    if _is_taste_job_duplicate(job_id, now):
+        logger.debug("Skipping duplicate taste job %s for user %s item %s", job_id, user_id, item_id)
+        return False
+
+    _ensure_taste_worker_running()
+    try:
+        _get_taste_job_queue().put_nowait(
+            {
+                "job_id": job_id,
+                "user_id": user_id,
+                "item_id": item_id,
+                "image_url": image_url,
+                "gallery_image_index": gallery_image_index,
+            }
+        )
+    except asyncio.QueueFull:
+        _TASTE_JOB_IN_FLIGHT.pop(job_id, None)
+        logger.warning(
+            "Taste-profile job queue full, dropping queue request for job %s (item %s, user %s)",
+            job_id,
+            item_id,
+            user_id,
+        )
+        raise
+    logger.info("Queued taste-profile job %s for item %s (user %s)", job_id, item_id, user_id)
+    return True
+
+
+async def _run_in_executor_with_retry(
+    operation,
+    *,
+    operation_name: str,
+    max_attempts: int,
+    base_delay_seconds: float,
+) -> Any:
+    last_exception: Exception | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return await asyncio.get_running_loop().run_in_executor(None, operation)
+        except Exception as exc:  # noqa: BLE001
+            last_exception = exc
+            if attempt >= max_attempts:
+                break
+            delay = min(_TASTE_JOB_MAX_BACKOFF_SECONDS, base_delay_seconds * (2 ** (attempt - 1)))
+            delay += random.uniform(0.0, _TASTE_JOB_JITTER_SECONDS)
+            logger.warning(
+                "Retryable failure in %s (%d/%d): %s. Retrying in %.2fs",
+                operation_name,
+                attempt,
+                max_attempts,
+                exc,
+                delay,
+            )
+            await asyncio.sleep(delay)
+
+    raise RuntimeError(f"{operation_name} failed after {max_attempts} attempts: {last_exception}") from last_exception
+
+
+async def _run_taste_profile_job(job: dict[str, Any]) -> None:
+    image_url = job["image_url"]
+    item_id = job["item_id"]
+    user_id = job["user_id"]
+    job_id = job["job_id"]
+
+    from agents.image_taste_analyzer import analyze_image, build_taste_inferred
+    from agents.taste_calibration import _update_user_profile
+
+    analysis = await _run_in_executor_with_retry(
+        lambda: analyze_image(image_url),
+        operation_name=f"analyze_image:{item_id}:{job_id}",
+        max_attempts=_TASTE_JOB_MAX_RETRIES,
+        base_delay_seconds=_TASTE_JOB_BASE_BACKOFF_SECONDS,
+    )
+    inferred = build_taste_inferred(analysis)
+    if not inferred["styleKeywords"] and not inferred["brands"]:
+        logger.info("Vision analysis yielded no taste for %s (job %s)", item_id, job_id)
+        return
+
+    await _run_in_executor_with_retry(
+        lambda: _update_user_profile(user_id, inferred),
+        operation_name=f"update_user_profile:{item_id}:{job_id}",
+        max_attempts=_TASTE_JOB_PROFILE_UPDATE_MAX_RETRIES,
+        base_delay_seconds=_TASTE_JOB_BASE_BACKOFF_SECONDS * 2,
+    )
+    logger.info(
+        "Taste profile updated from vision for user %s, item %s: %s",
+        user_id,
+        item_id,
+        inferred["styleKeywords"][:4],
+    )
+
+
+async def _taste_job_worker() -> None:
+    logger.info("Starting taste-profile feedback worker.")
+    queue = _get_taste_job_queue()
+    try:
+        while True:
+            try:
+                job = await queue.get()
+            except asyncio.CancelledError:
+                logger.info("Taste-profile feedback worker cancelled; draining outstanding jobs.")
+                _drain_taste_job_queue_for_shutdown(queue)
+                raise
+
+            job_id = job.get("job_id", "")
+            try:
+                await _run_taste_profile_job(job)
+            except asyncio.CancelledError:
+                logger.warning(
+                    "Taste-profile job cancelled before completion; persisting for retry: %s",
+                    job_id,
+                )
+                _persist_taste_job(job)
+                queue.task_done()
+                _drain_taste_job_queue_for_shutdown(queue)
+                raise
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Taste-profile job failed: %s", exc)
+                queue.task_done()
+            else:
+                if job_id:
+                    _mark_taste_job_completed(job_id, now=time.monotonic())
+                queue.task_done()
+    except asyncio.CancelledError:
+        logger.info("Taste-profile feedback worker stopped.")
+        raise
+
 
 def _get_env(name: str, default: Optional[str] = None) -> str:
     value = os.getenv(name, default)
@@ -1486,8 +1745,8 @@ async def feedback_scraped_item(
         item["scoreSignal"] = item.get("scoreSignal", 0) + delta
         await container.upsert_item(item)
 
-        # On like/dislike: run vision analysis on the image to extract real visual
-        # style descriptors (colors, silhouette, garments) — not just post-text tags.
+        # On like: enqueue vision analysis on the image to extract real visual
+        # style descriptors (colors, silhouette, garments) in the background.
         # When a gallery index is provided, analyse that specific image.
         gallery_images = item.get("galleryImages", [])
         if (
@@ -1499,28 +1758,19 @@ async def feedback_scraped_item(
         else:
             image_url = item.get("imageUrl", "")
         if image_url and signal == "up":
-            # Run vision analysis synchronously in a thread pool so we can await it
-            # and guarantee it completes before the connection closes.
-            # (asyncio.create_task fire-and-forget is unreliable in ASGI on Functions.)
             try:
-                from agents.image_taste_analyzer import analyze_image, build_taste_inferred
-                from agents.taste_calibration import _update_user_profile
-                logger.info("Starting vision taste analysis for item %s (url: %s)", item_id, image_url[:60])
-                analysis = await asyncio.get_event_loop().run_in_executor(
-                    None, lambda: analyze_image(image_url)
-                )
-                logger.info("Vision analysis result for %s: %s", item_id, analysis)
-                inferred = build_taste_inferred(analysis)
-                if inferred["styleKeywords"] or inferred["brands"]:
-                    await asyncio.get_event_loop().run_in_executor(
-                        None, lambda: _update_user_profile(user_id, inferred)
-                    )
-                    logger.info(
-                        "Taste updated for %s via vision: %s",
-                        user_id, inferred["styleKeywords"][:4],
-                    )
+                if _maybe_enqueue_taste_job(
+                    user_id=user_id,
+                    item_id=item_id,
+                    image_url=image_url,
+                    gallery_image_index=gallery_image_index,
+                    signal=signal,
+                ):
+                    logger.debug("Queued vision taste extraction job for %s", item_id)
+                else:
+                    logger.debug("Skipped duplicate vision job for %s", item_id)
             except Exception as _vision_exc:  # noqa: BLE001
-                logger.warning("Vision taste update failed for %s: %s", item_id, _vision_exc)
+                logger.warning("Vision taste enqueue failed for %s: %s", item_id, _vision_exc)
 
         return {"itemId": item_id, "signal": signal, "scoreSignal": item["scoreSignal"]}
     except Exception as exc:

--- a/PluckIt.Processor/tests/unit/test_routes.py
+++ b/PluckIt.Processor/tests/unit/test_routes.py
@@ -9,7 +9,9 @@ Unit tests for FastAPI routes in function_app.py:
   - GET  /api/digest/feedback
   - POST /api/digest/feedback
 """
-from unittest.mock import AsyncMock, MagicMock, patch
+import asyncio
+from contextlib import suppress
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 from collections.abc import AsyncGenerator, Callable
 
 from fastapi import HTTPException
@@ -384,3 +386,257 @@ async def test_delete_scraper_source_subscription(async_client):
     payload = response.json()
     assert payload["sourceId"] == "source-1"
     assert payload["subscribed"] is False
+
+
+@pytest.mark.unit
+async def test_post_scraper_item_feedback_up_queues_background_taste_job(async_client):
+    container = MagicMock()
+    container.read_item = AsyncMock(return_value={"id": "item-001", "imageUrl": "https://cdn.example.com/item.png", "galleryImages": ["https://cdn.example.com/item-a.png", "https://cdn.example.com/item-b.png"], "scoreSignal": 0})
+    container.upsert_item = AsyncMock(return_value={"id": "item-001", "scoreSignal": 1})
+
+    with patch("agents.db.get_scraped_items_container", return_value=container), patch(
+        "function_app._maybe_enqueue_taste_job", return_value=True
+    ) as mock_enqueue:
+        response = await async_client.post(
+            "/api/scraper/items/item-001/feedback",
+            json={"signal": "up", "galleryImageIndex": 1},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"itemId": "item-001", "signal": "up", "scoreSignal": 1}
+    container.read_item.assert_awaited_once_with(item="item-001", partition_key="global")
+    mock_enqueue.assert_called_once_with(
+        user_id="test-user-001",
+        item_id="item-001",
+        image_url="https://cdn.example.com/item-b.png",
+        gallery_image_index=1,
+        signal="up",
+    )
+
+
+@pytest.mark.unit
+async def test_post_scraper_item_feedback_down_skips_taste_job(async_client):
+    container = MagicMock()
+    container.read_item = AsyncMock(return_value={"id": "item-001", "imageUrl": "https://cdn.example.com/item.png", "scoreSignal": 0})
+    container.upsert_item = AsyncMock(return_value={"id": "item-001", "scoreSignal": -1})
+
+    with patch("agents.db.get_scraped_items_container", return_value=container), patch(
+        "function_app._maybe_enqueue_taste_job"
+    ) as mock_enqueue:
+        response = await async_client.post(
+            "/api/scraper/items/item-001/feedback",
+            json={"signal": "down"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"itemId": "item-001", "signal": "down", "scoreSignal": -1}
+    mock_enqueue.assert_not_called()
+
+
+@pytest.mark.unit
+async def test_feedback_rejects_invalid_signal(async_client):
+    response = await async_client.post(
+        "/api/scraper/items/item-001/feedback",
+        json={"signal": "meh"},
+    )
+
+    assert response.status_code == 400
+
+
+@pytest.mark.unit
+def test_maybe_enqueue_taste_job_dedupe_guard():
+    from function_app import (
+        _maybe_enqueue_taste_job,
+        _TASTE_JOB_COMPLETED,
+        _TASTE_JOB_IN_FLIGHT,
+    )
+
+    _TASTE_JOB_IN_FLIGHT.clear()
+    _TASTE_JOB_COMPLETED.clear()
+
+    queue: list[dict] = []
+
+    class _Queue:
+        def put_nowait(self, item: dict) -> None:
+            queue.append(item)
+
+    with patch("function_app._ensure_taste_worker_running"), patch("function_app._get_taste_job_queue", return_value=_Queue()):
+        first = _maybe_enqueue_taste_job(
+            user_id="user-001",
+            item_id="item-001",
+            image_url="https://cdn.example.com/item.png",
+            gallery_image_index=0,
+            signal="up",
+        )
+        duplicate = _maybe_enqueue_taste_job(
+            user_id="user-001",
+            item_id="item-001",
+            image_url="https://cdn.example.com/item.png",
+            gallery_image_index=0,
+            signal="up",
+        )
+
+    assert first is True
+    assert duplicate is False
+    assert len(queue) == 1
+    assert any("job_id" in item for item in queue)
+
+
+@pytest.mark.unit
+async def test_run_in_executor_with_retry_retries_and_succeeds():
+    import function_app
+
+    calls: dict[str, int] = {"count": 0}
+
+    def _operation() -> str:
+        calls["count"] += 1
+        if calls["count"] < 2:
+            raise RuntimeError("transient")
+        return "ok"
+
+    with patch("function_app.random.uniform", return_value=0.0):
+        result = await function_app._run_in_executor_with_retry(
+            _operation,
+            operation_name="test-op",
+            max_attempts=3,
+            base_delay_seconds=0.0,
+        )
+
+    assert result == "ok"
+    assert calls["count"] == 2
+
+
+@pytest.mark.unit
+async def test_run_in_executor_with_retry_bubbles_after_exhaustion():
+    import function_app
+
+    calls: dict[str, int] = {"count": 0}
+
+    def _operation() -> str:
+        calls["count"] += 1
+        raise RuntimeError("always-fails")
+
+    with patch("function_app.random.uniform", return_value=0.0):
+        with pytest.raises(RuntimeError):
+            await function_app._run_in_executor_with_retry(
+                _operation,
+                operation_name="test-op",
+                max_attempts=2,
+                base_delay_seconds=0.0,
+            )
+
+    assert calls["count"] == 2
+
+
+@pytest.mark.unit
+async def test_run_taste_profile_job_updates_profile_when_inferred_data_exists():
+    import function_app
+
+    job = {
+        "job_id": "job-abc",
+        "user_id": "test-user-001",
+        "item_id": "item-001",
+        "image_url": "https://cdn.example.com/item.png",
+    }
+
+    def _fake_retry(operation, *, operation_name, max_attempts, base_delay_seconds):
+        if "analyze_image" in operation_name:
+            return {
+                "styleKeywords": ["minimal", "cotton"],
+                "colors": ["white"],
+                "garments": ["shirt"],
+                "brand": "Test",
+            }
+        return None
+
+    with patch(
+        "function_app._run_in_executor_with_retry",
+        new=AsyncMock(side_effect=_fake_retry),
+    ) as mock_retry:
+        await function_app._run_taste_profile_job(job)
+
+    assert mock_retry.call_count == 2
+    mock_retry.assert_any_call(
+        ANY,
+        operation_name="analyze_image:item-001:job-abc",
+        max_attempts=3,
+        base_delay_seconds=function_app._TASTE_JOB_BASE_BACKOFF_SECONDS,
+    )
+    mock_retry.assert_any_call(
+        ANY,
+        operation_name="update_user_profile:item-001:job-abc",
+        max_attempts=2,
+        base_delay_seconds=function_app._TASTE_JOB_BASE_BACKOFF_SECONDS * 2,
+    )
+
+
+@pytest.mark.unit
+async def test_taste_job_worker_logs_and_continues_on_failure():
+    import function_app
+
+    queue = asyncio.Queue()
+    await queue.put({"job_id": "job-1", "user_id": "u-1", "item_id": "item-1", "image_url": "https://cdn.example.com/1.png"})
+    await queue.put({"job_id": "job-2", "user_id": "u-1", "item_id": "item-2", "image_url": "https://cdn.example.com/2.png"})
+
+    def _run_taste_profile_job_side_effect(job: dict[str, object]) -> None:
+        if job["job_id"] == "job-1":
+            raise RuntimeError("transient job failure")
+
+    with patch("function_app._get_taste_job_queue", return_value=queue), patch(
+        "function_app._run_taste_profile_job",
+        side_effect=_run_taste_profile_job_side_effect,
+    ) as mock_run:
+        worker_task = asyncio.create_task(function_app._taste_job_worker())
+        await queue.join()
+        worker_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await worker_task
+
+    assert mock_run.call_count == 2
+
+
+@pytest.mark.unit
+async def test_taste_job_worker_persists_pending_jobs_on_cancellation():
+    import function_app
+
+    queue = asyncio.Queue()
+    await queue.put({"job_id": "job-1", "user_id": "u-1", "item_id": "item-1", "image_url": "https://cdn.example.com/1.png"})
+    await queue.put({"job_id": "job-2", "user_id": "u-1", "item_id": "item-2", "image_url": "https://cdn.example.com/2.png"})
+    job_started = asyncio.Event()
+
+    async def _block_job(_: dict[str, object]) -> None:
+        job_started.set()
+        await asyncio.Future()
+
+    with patch("function_app._get_taste_job_queue", return_value=queue), patch(
+        "function_app._run_taste_profile_job",
+        side_effect=_block_job,
+    ) as mock_run, patch("function_app._persist_taste_job") as mock_persist:
+        worker_task = asyncio.create_task(function_app._taste_job_worker())
+        await job_started.wait()
+        worker_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await worker_task
+
+    assert mock_run.call_count == 1
+    assert mock_persist.call_count == 2
+
+
+@pytest.mark.unit
+async def test_taste_job_worker_marks_completed_only_on_success():
+    import function_app
+
+    queue = asyncio.Queue()
+    await queue.put({"job_id": "job-fail", "user_id": "u-1", "item_id": "item-1", "image_url": "https://cdn.example.com/1.png"})
+
+    with patch("function_app._get_taste_job_queue", return_value=queue), patch(
+        "function_app._run_taste_profile_job",
+        side_effect=RuntimeError("failure"),
+    ), patch("function_app._mark_taste_job_completed") as mark_completed:
+        worker_task = asyncio.create_task(function_app._taste_job_worker())
+        await queue.join()
+        worker_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await worker_task
+
+    mark_completed.assert_not_called()


### PR DESCRIPTION
- Added a new in-memory queue for managing taste jobs, including deduplication mechanisms to prevent duplicate processing.
- Introduced environment variable configurations for job handling parameters such as TTL and backoff settings.
- Enhanced the `_maybe_enqueue_taste_job` function to handle job queuing and logging.
- Implemented unit tests to validate the new taste job functionality and ensure proper behavior under various conditions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Vision analysis for taste profiling now executes asynchronously in the background, improving response times when upvoting items.
  * Automatic retry logic with backoff for preference profile updates.
  * Deduplication system prevents redundant analysis tasks from being queued.

* **Tests**
  * Added comprehensive unit tests for preference profiling workflows and feedback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->