### PR TITLE
Feature/52 resolve phash linear scan

### DIFF
--- a/PluckIt.Processor/agents/scrapers/deduplicator.py
+++ b/PluckIt.Processor/agents/scrapers/deduplicator.py
@@ -50,11 +50,9 @@ def _candidate_buckets_cached(bucket: str) -> tuple[str, ...]:
                 mask |= 1 << bit
             candidates.add(base ^ mask)
 
-    max_value = (1 << PHASH_PREFIX_BITS) - 1
     return tuple(
         f"{value:0{PHASH_PREFIX_CHARS}x}"
         for value in candidates
-        if value <= max_value
     )
 
 

--- a/PluckIt.Processor/tests/unit/test_deduplicator.py
+++ b/PluckIt.Processor/tests/unit/test_deduplicator.py
@@ -6,7 +6,11 @@ No Cosmos or network calls — all state is injected directly.
 
 import pytest
 
-from agents.scrapers.deduplicator import RunDeduplicator, PHASH_THRESHOLD
+from agents.scrapers.deduplicator import (
+    PHASH_PREFIX_CHARS,
+    PHASH_THRESHOLD,
+    RunDeduplicator,
+)
 
 
 # ── URL dedup ─────────────────────────────────────────────────────────────────
@@ -36,6 +40,13 @@ def _make_dedup_with_phash(existing_hash: str) -> RunDeduplicator:
     return dedup
 
 
+def _flip_bits(hash_value: str, bit_count: int) -> str:
+    """Return `hash_value` with the lowest `bit_count` bits flipped."""
+    if bit_count <= 0:
+        return hash_value
+    return f"{int(hash_value, 16) ^ ((1 << bit_count) - 1):0{len(hash_value)}x}"
+
+
 def test_phash_dedup_identical_hash():
     """Hamming distance 0 — clearly duplicate."""
     h = "a" * 16  # 64-bit pHash hex
@@ -55,6 +66,24 @@ def test_phash_dedup_nearby_prefix_variation_is_detected():
     """Flipping a top-bit prefix still counts as duplicate at threshold 5."""
     existing = "1111111111111111"
     candidate = f"{int(existing, 16) ^ (1 << 60):016x}"  # diff = 1 bit, different prefix
+    dedup = _make_dedup_with_phash(existing)
+    assert dedup.is_duplicate("https://reddit.com/new", phash=candidate) is True
+
+
+def test_phash_dedup_at_threshold_boundary():
+    """A candidate at exactly `PHASH_THRESHOLD` bits is not a duplicate."""
+    hash_len = max(PHASH_PREFIX_CHARS, (PHASH_THRESHOLD + 3) // 4)
+    existing = "a" * hash_len
+    candidate = _flip_bits(existing, PHASH_THRESHOLD)
+    dedup = _make_dedup_with_phash(existing)
+    assert dedup.is_duplicate("https://reddit.com/new", phash=candidate) is False
+
+
+def test_phash_dedup_just_under_threshold():
+    """A candidate at one bit under `PHASH_THRESHOLD` is still duplicate."""
+    hash_len = max(PHASH_PREFIX_CHARS, (PHASH_THRESHOLD + 3) // 4)
+    existing = "a" * hash_len
+    candidate = _flip_bits(existing, PHASH_THRESHOLD - 1)
     dedup = _make_dedup_with_phash(existing)
     assert dedup.is_duplicate("https://reddit.com/new", phash=candidate) is True
 


### PR DESCRIPTION
Replaced linear scan storage with prefix buckets so pHash checks no longer iterate across all historical hashes.
Added fast candidate retrieval using first-4-hex-char buckets (16-bit prefix).
Preserved dedupe correctness for threshold-based matching.

Closes #52 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced duplicate detection performance using optimized prefix-based indexing and caching strategies.
  * Improved accuracy in identifying near-duplicate items within configured threshold parameters.

* **Tests**
  * Added test coverage for duplicate detection with minimal prefix variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->