### PR TITLE
feat: add Cosmos image cleanup index functionality

### DIFF
--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -43,6 +43,11 @@ if app_type == "dotnet":
 		"Cosmos__Key": pick("COSMOS_KEY", "AZURE_COSMOS_KEY", "Cosmos__Key"),
 		"Cosmos__Database": pick("COSMOS_DATABASE", "Cosmos__Database", default="PluckIt"),
 		"Cosmos__Container": pick("COSMOS_CONTAINER", "Cosmos__Container", default="Wardrobe"),
+		"Cosmos__ImageCleanupIndexContainer": pick(
+			"COSMOS_IMAGE_CLEANUP_INDEX_CONTAINER",
+			"Cosmos__ImageCleanupIndexContainer",
+			default="WardrobeImageCleanupIndex",
+		),
 		"AI__Endpoint": pick("AZURE_OPENAI_ENDPOINT", "AI__Endpoint"),
 		"AI__ApiKey": pick("AZURE_OPENAI_API_KEY", "AI__ApiKey"),
 		"AI__Deployment": pick("AZURE_OPENAI_DEPLOYMENT", "AI__Deployment", default="gpt-4.1-mini"),

--- a/PluckIt.Core/WardrobeImageCleanupIndex.cs
+++ b/PluckIt.Core/WardrobeImageCleanupIndex.cs
@@ -1,0 +1,27 @@
+namespace PluckIt.Core;
+
+/// <summary>
+/// Shared contract for the wardrobe image cleanup index container.
+/// </summary>
+public static class WardrobeImageCleanupIndex
+{
+    /// <summary>
+    /// Environment setting that points to the cleanup index container.
+    /// </summary>
+    public const string ContainerSettingName = "Cosmos__ImageCleanupIndexContainer";
+
+    /// <summary>
+    /// Default name used when the setting is not provided.
+    /// </summary>
+    public const string DefaultContainerName = "WardrobeImageCleanupIndex";
+
+    /// <summary>
+    /// Constant partition key value used by all index documents.
+    /// </summary>
+    public const string PartitionKeyValue = "global";
+
+    /// <summary>
+    /// Partition key path for the Cosmos container.
+    /// </summary>
+    public const string PartitionKeyPath = "/partition";
+}

--- a/PluckIt.Functions/Functions/CleanupFunctions.cs
+++ b/PluckIt.Functions/Functions/CleanupFunctions.cs
@@ -24,11 +24,13 @@ public class CleanupFunctions(
 {
     private const string TransparentSuffix = "-transparent.png";
 
-    private static (string dbName, string containerName) GetCosmosConfig()
+    private static (string dbName, string wardrobeContainerName, string? imageCleanupIndexContainerName) GetCosmosConfig()
     {
         var dbName = Environment.GetEnvironmentVariable("Cosmos__Database") ?? "PluckIt";
         var containerName = Environment.GetEnvironmentVariable("Cosmos__Container") ?? "Wardrobe";
-        return (dbName, containerName);
+        var imageCleanupIndexContainerName = Environment.GetEnvironmentVariable(
+            WardrobeImageCleanupIndex.ContainerSettingName);
+        return (dbName, containerName, imageCleanupIndexContainerName);
     }
 
     private static (string accountName, string archiveContainer) GetStorageConfig()
@@ -53,19 +55,37 @@ public class CleanupFunctions(
 
     private async Task<HashSet<string>> GetKnownItemIdsAsync(CancellationToken cancellationToken)
     {
-        var knownIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        var (dbName, containerName) = GetCosmosConfig();
+        var (dbName, wardrobeContainerName, imageCleanupIndexContainerName) = GetCosmosConfig();
+        var useImageCleanupIndex = !string.IsNullOrWhiteSpace(imageCleanupIndexContainerName);
+        var containerName = useImageCleanupIndex
+            ? imageCleanupIndexContainerName!
+            : wardrobeContainerName;
         var container = cosmosClient.GetContainer(dbName, containerName);
 
-        var query = new QueryDefinition("SELECT c.id FROM c WHERE IS_DEFINED(c.imageUrl)");
+        var query = useImageCleanupIndex
+            ? new QueryDefinition("SELECT c.itemId FROM c")
+            : new QueryDefinition("SELECT c.id FROM c WHERE IS_DEFINED(c.imageUrl)");
+        var queryOptions = new QueryRequestOptions
+        {
+            MaxItemCount = 500,
+            PartitionKey = useImageCleanupIndex
+                ? new PartitionKey(WardrobeImageCleanupIndex.PartitionKeyValue)
+                : null,
+        };
+        var knownIds = await ReadKnownItemIdsAsync(container, query, queryOptions, cancellationToken);
+        return knownIds;
+    }
+
+    private static async Task<HashSet<string>> ReadKnownItemIdsAsync(
+        Container container,
+        QueryDefinition query,
+        QueryRequestOptions requestOptions,
+        CancellationToken cancellationToken)
+    {
+        var knownIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var iterator = container.GetItemQueryStreamIterator(
             query,
-            requestOptions: new QueryRequestOptions
-            {
-                MaxItemCount = 500,
-            });
-
+            requestOptions: requestOptions);
         while (iterator.HasMoreResults)
         {
             using var response = await iterator.ReadNextAsync(cancellationToken);
@@ -84,7 +104,10 @@ public class CleanupFunctions(
             {
                 if (!item.TryGetProperty("id", out var idProp))
                 {
-                    continue;
+                    if (!item.TryGetProperty("itemId", out idProp))
+                    {
+                        continue;
+                    }
                 }
 
                 var id = idProp.GetString();
@@ -94,7 +117,6 @@ public class CleanupFunctions(
                 }
             }
         }
-
         return knownIds;
     }
 
@@ -107,8 +129,9 @@ public class CleanupFunctions(
     {
         logger.LogInformation("Orphan blob cleanup started at {Time}", DateTimeOffset.UtcNow);
 
-        // ── 1. Collect all known item IDs from Cosmos (cross-partition) ───────
-        // We read only the /id field to minimise RU cost.
+        // ── 1. Collect all known item IDs from Cosmos ────────────────────
+        // Prefer the cleanup index container when configured; otherwise
+        // use the legacy wardrobe scan.
         try
         {
             var knownIds = await GetKnownItemIdsAsync(cancellationToken);

--- a/PluckIt.Functions/Program.cs
+++ b/PluckIt.Functions/Program.cs
@@ -106,7 +106,8 @@ var host = new HostBuilder()
             new WardrobeRepository(
                 sp.GetRequiredService<CosmosClient>(),
                 cosmosDatabase,
-                cosmosContainer));
+                cosmosContainer,
+                config["Cosmos:ImageCleanupIndexContainer"] ?? WardrobeImageCleanupIndex.DefaultContainerName));
 
         var cosmosWearEventsContainer = config["Cosmos:WearEventsContainer"] ?? "WearEvents";
         services.AddSingleton<IWearHistoryRepository>(sp =>

--- a/PluckIt.Functions/local.settings.json.example
+++ b/PluckIt.Functions/local.settings.json.example
@@ -10,6 +10,7 @@
     "Cosmos__Key": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b5S5O4FhfJLkfB6NWNFNJ+Mfzq8R7uoB8g==",
     "Cosmos__Database": "PluckIt",
     "Cosmos__Container": "Wardrobe",
+    "Cosmos__ImageCleanupIndexContainer": "WardrobeImageCleanupIndex",
     "Cosmos__RefreshTokensContainer": "RefreshTokens",
 
     "AI__Endpoint": "https://<your-resource>.openai.azure.com/",

--- a/PluckIt.Infrastructure/WardrobeRepository.cs
+++ b/PluckIt.Infrastructure/WardrobeRepository.cs
@@ -14,15 +14,79 @@ public class WardrobeRepository : IWardrobeRepository
   private readonly CosmosClient _client;
   private readonly string _databaseName;
   private readonly string _containerName;
+  private readonly string? _imageCleanupIndexContainerName;
+  private Container? _imageCleanupIndexContainer;
 
-  public WardrobeRepository(CosmosClient client, string databaseName, string containerName)
+  public WardrobeRepository(
+    CosmosClient client,
+    string databaseName,
+    string containerName,
+    string? imageCleanupIndexContainerName = null)
   {
     _client = client ?? throw new ArgumentNullException(nameof(client));
     _databaseName = databaseName ?? throw new ArgumentNullException(nameof(databaseName));
     _containerName = containerName ?? throw new ArgumentNullException(nameof(containerName));
+    _imageCleanupIndexContainerName = string.IsNullOrWhiteSpace(imageCleanupIndexContainerName)
+      ? null
+      : imageCleanupIndexContainerName;
   }
 
   private Container Container => _client.GetContainer(_databaseName, _containerName);
+  private Container? ImageCleanupIndexContainer => _imageCleanupIndexContainerName is null
+    ? null
+    : _imageCleanupIndexContainer ??= _client.GetContainer(_databaseName, _imageCleanupIndexContainerName);
+
+  private static string BuildCleanupIndexId(string userId, string itemId) => $"{userId}:{itemId}";
+
+  private async Task SyncImageCleanupIndexAsync(ClothingItem item, CancellationToken cancellationToken)
+  {
+    var indexContainer = ImageCleanupIndexContainer;
+    if (indexContainer is null)
+    {
+      return;
+    }
+
+    if (string.IsNullOrWhiteSpace(item.ImageUrl))
+    {
+      await DeleteImageCleanupIndexAsync(item.UserId, item.Id, cancellationToken);
+      return;
+    }
+
+    await indexContainer.UpsertItemAsync(
+      new ClothingImageCleanupIndexEntry
+      {
+        Id = BuildCleanupIndexId(item.UserId, item.Id),
+        ItemId = item.Id,
+        UserId = item.UserId,
+        Partition = WardrobeImageCleanupIndex.PartitionKeyValue,
+      },
+      new PartitionKey(WardrobeImageCleanupIndex.PartitionKeyValue),
+      cancellationToken: cancellationToken);
+  }
+
+  private async Task DeleteImageCleanupIndexAsync(
+    string userId,
+    string itemId,
+    CancellationToken cancellationToken)
+  {
+    var indexContainer = ImageCleanupIndexContainer;
+    if (indexContainer is null)
+    {
+      return;
+    }
+
+    try
+    {
+      await indexContainer.DeleteItemAsync<ClothingImageCleanupIndexEntry>(
+        BuildCleanupIndexId(userId, itemId),
+        new PartitionKey(WardrobeImageCleanupIndex.PartitionKeyValue),
+        cancellationToken: cancellationToken);
+    }
+    catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+    {
+      // already absent
+    }
+  }
 
   // Maps the allowlisted sort-field identifiers to Cosmos SQL field references.
   private static readonly Dictionary<string, string> SortFieldMap =
@@ -170,6 +234,7 @@ public class WardrobeRepository : IWardrobeRepository
       item,
       new PartitionKey(item.UserId),
       cancellationToken: cancellationToken);
+    await SyncImageCleanupIndexAsync(item, cancellationToken);
   }
 
     public async Task DeleteAsync(
@@ -183,9 +248,11 @@ public class WardrobeRepository : IWardrobeRepository
         id,
         new PartitionKey(userId),
         cancellationToken: cancellationToken);
+      await DeleteImageCleanupIndexAsync(userId, id, cancellationToken);
     }
     catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
     {
+      await DeleteImageCleanupIndexAsync(userId, id, cancellationToken);
       // Already deleted — treat as success
     }
   }
@@ -308,8 +375,9 @@ public class WardrobeRepository : IWardrobeRepository
 
     try
     {
-      await Container.PatchItemAsync<ClothingItem>(
+      var response = await Container.PatchItemAsync<ClothingItem>(
         itemId, new PartitionKey(userId), ops, options, cancellationToken);
+      await SyncImageCleanupIndexAsync(response.Resource, cancellationToken);
       return true;
     }
     catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.PreconditionFailed)
@@ -391,5 +459,16 @@ public class WardrobeRepository : IWardrobeRepository
       results.AddRange(page);
     }
     return results;
+  }
+
+  /// <summary>
+  /// Lightweight record stored in the cleanup-index Cosmos container.
+  /// </summary>
+  public sealed class ClothingImageCleanupIndexEntry
+  {
+    public string Id { get; init; } = string.Empty;
+    public string ItemId { get; init; } = string.Empty;
+    public string UserId { get; init; } = string.Empty;
+    public string Partition { get; init; } = string.Empty;
   }
 }

--- a/PluckIt.Tests/Unit/Functions/CleanupFunctionsTests.cs
+++ b/PluckIt.Tests/Unit/Functions/CleanupFunctionsTests.cs
@@ -59,12 +59,13 @@ public sealed class CleanupFunctionsTests
     /// a simulated JSON response containing the provided item IDs.
     /// Cosmos returns pages shaped roughly like { "Documents": [ {"id":"abc"}, ... ] }
     /// </summary>
-    private void SetupCosmosQueryIterator(params string[] itemIds)
+    private void SetupCosmosQueryIterator(bool itemIdFieldOnly, params string[] itemIds)
     {
         var docs = new List<string>();
+        var fieldName = itemIdFieldOnly ? "itemId" : "id";
         foreach (var id in itemIds)
         {
-            docs.Add($$"""{"id":"{{id}}"}""");
+            docs.Add($$"""{"{{fieldName}}":"{{id}}"}""");
         }
         var pageJson = $$"""{"Documents": [ {{string.Join(",", docs)}} ]}""";
 
@@ -90,7 +91,7 @@ public sealed class CleanupFunctionsTests
     public async Task CleanUpOrphanBlobs_KnownBlob_IsSkipped()
     {
         // Cosmos knows about "item-123"
-        SetupCosmosQueryIterator("item-123");
+        SetupCosmosQueryIterator(false, "item-123");
 
         // Storage has a blob named "item-123-transparent.png"
         _sasService.ArchiveBlobNames.Add("item-123-transparent.png");
@@ -105,7 +106,7 @@ public sealed class CleanupFunctionsTests
     public async Task CleanUpOrphanBlobs_OrphanBlob_IsDeleted()
     {
         // Cosmos knows about "item-123"
-        SetupCosmosQueryIterator("item-123");
+        SetupCosmosQueryIterator(false, "item-123");
 
         // Storage has a blob named "orphan-999-transparent.png"
         _sasService.ArchiveBlobNames.Add("orphan-999-transparent.png");
@@ -120,7 +121,7 @@ public sealed class CleanupFunctionsTests
     [Fact]
     public async Task CleanUpOrphanBlobs_MixedBlobs_DeletesOnlyOrphans()
     {
-        SetupCosmosQueryIterator("known-1", "known-2");
+        SetupCosmosQueryIterator(false, "known-1", "known-2");
         _sasService.ArchiveBlobNames.AddRange(MixedOrphanBlobNames);
 
         await _sut.CleanUpOrphanBlobs(CreateDummyTimer(), CancellationToken.None);
@@ -133,7 +134,7 @@ public sealed class CleanupFunctionsTests
     [Fact]
     public async Task CleanUpOrphanBlobs_EmptyStorage_NoOps()
     {
-        SetupCosmosQueryIterator("some-item");
+        SetupCosmosQueryIterator(false, "some-item");
         // Storage has no blobs
 
         await _sut.CleanUpOrphanBlobs(CreateDummyTimer(), CancellationToken.None);
@@ -159,5 +160,25 @@ public sealed class CleanupFunctionsTests
 
         // But no deletes should have been issued because Cosmos read failed (fail-safe)
         _sasService.DeletedUrls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task CleanUpOrphanBlobs_UsesImageCleanupIndexPayload()
+    {
+        var previousIndexContainer = Environment.GetEnvironmentVariable("Cosmos__ImageCleanupIndexContainer");
+        Environment.SetEnvironmentVariable("Cosmos__ImageCleanupIndexContainer", "WardrobeImageCleanupIndex");
+        try
+        {
+            SetupCosmosQueryIterator(true, "known-1");
+            _sasService.ArchiveBlobNames.Add("known-1-transparent.png");
+
+            await _sut.CleanUpOrphanBlobs(CreateDummyTimer(), CancellationToken.None);
+
+            _sasService.DeletedUrls.ShouldBeEmpty();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("Cosmos__ImageCleanupIndexContainer", previousIndexContainer);
+        }
     }
 }

--- a/PluckIt.Tests/Unit/Infrastructure/WardrobeRepositoryTests.cs
+++ b/PluckIt.Tests/Unit/Infrastructure/WardrobeRepositoryTests.cs
@@ -13,6 +13,7 @@ public sealed class WardrobeRepositoryTests
 {
     private const string DatabaseName = "test-db";
     private const string ContainerName = "wardrobe";
+    private const string ImageCleanupIndexContainerName = "wardrobe-image-cleanup";
 
     private readonly Mock<CosmosClient> _mockClient = new(MockBehavior.Strict);
     private readonly Mock<Container> _mockContainer = new(MockBehavior.Strict);
@@ -36,6 +37,25 @@ public sealed class WardrobeRepositoryTests
             WearCount = wearCount,
             WearEvents = events.ToList(),
         };
+
+    private static (WardrobeRepository Sut, Mock<CosmosClient> Client, Mock<Container> WardrobeContainer, Mock<Container> CleanupContainer)
+      CreateRepositoryWithImageIndex()
+    {
+      var client = new Mock<CosmosClient>(MockBehavior.Strict);
+      var wardrobeContainer = new Mock<Container>(MockBehavior.Strict);
+      var cleanupContainer = new Mock<Container>(MockBehavior.Loose);
+
+      client.Setup(c => c.GetContainer(DatabaseName, ContainerName)).Returns(wardrobeContainer.Object);
+      client.Setup(c => c.GetContainer(DatabaseName, ImageCleanupIndexContainerName)).Returns(cleanupContainer.Object);
+
+      var sut = new WardrobeRepository(
+        client.Object,
+        DatabaseName,
+        ContainerName,
+        ImageCleanupIndexContainerName);
+
+      return (sut, client, wardrobeContainer, cleanupContainer);
+    }
 
     [Fact]
     public void Ctor_RejectsNullClient()
@@ -159,6 +179,65 @@ public sealed class WardrobeRepositoryTests
     }
 
     [Fact]
+    public async Task UpsertAsync_WithImageUrl_UpdatesImageCleanupIndex()
+    {
+        var (sut, _, wardrobeContainer, cleanupContainer) = CreateRepositoryWithImageIndex();
+        var item = MakeItem("with-image", "user");
+
+        wardrobeContainer
+            .Setup(c => c.UpsertItemAsync(item, new PartitionKey("user"), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CosmosTestHelpers.CreateItemResponse(item).Object);
+        cleanupContainer
+            .Setup(c => c.UpsertItemAsync(
+                It.IsAny<WardrobeRepository.ClothingImageCleanupIndexEntry>(),
+                new PartitionKey(WardrobeImageCleanupIndex.PartitionKeyValue),
+                null,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CosmosTestHelpers.CreateItemResponse(new WardrobeRepository.ClothingImageCleanupIndexEntry
+            {
+                Id = $"{item.UserId}:{item.Id}",
+                ItemId = item.Id,
+                UserId = item.UserId,
+                Partition = WardrobeImageCleanupIndex.PartitionKeyValue,
+            }).Object);
+
+        await sut.UpsertAsync(item, CancellationToken.None);
+
+        cleanupContainer.Invocations.ShouldContain(i => i.Method.Name == nameof(Container.UpsertItemAsync));
+        cleanupContainer.Invocations.ShouldNotContain(i => i.Method.Name == nameof(Container.DeleteItemAsync));
+    }
+
+    [Fact]
+    public async Task UpsertAsync_WithoutImageUrl_RemovesImageCleanupIndex()
+    {
+        var (sut, _, wardrobeContainer, cleanupContainer) = CreateRepositoryWithImageIndex();
+        var item = MakeItem("without-image", "user");
+        item.ImageUrl = null;
+
+        wardrobeContainer
+            .Setup(c => c.UpsertItemAsync(item, new PartitionKey("user"), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CosmosTestHelpers.CreateItemResponse(item).Object);
+        cleanupContainer
+            .Setup(c => c.DeleteItemAsync<WardrobeRepository.ClothingImageCleanupIndexEntry>(
+                $"{item.UserId}:{item.Id}",
+                new PartitionKey(WardrobeImageCleanupIndex.PartitionKeyValue),
+                null,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CosmosTestHelpers.CreateItemResponse(new WardrobeRepository.ClothingImageCleanupIndexEntry
+            {
+                Id = $"{item.UserId}:{item.Id}",
+                ItemId = item.Id,
+                UserId = item.UserId,
+                Partition = WardrobeImageCleanupIndex.PartitionKeyValue,
+            }).Object);
+
+        await sut.UpsertAsync(item, CancellationToken.None);
+
+        cleanupContainer.Invocations.ShouldContain(i => i.Method.Name == nameof(Container.DeleteItemAsync));
+        cleanupContainer.Invocations.ShouldNotContain(i => i.Method.Name == nameof(Container.UpsertItemAsync));
+    }
+
+    [Fact]
     public async Task DeleteAsync_NotFoundIsSwallowed()
     {
         _mockContainer
@@ -170,6 +249,39 @@ public sealed class WardrobeRepositoryTests
         _mockContainer.Verify(
             c => c.DeleteItemAsync<ClothingItem>("missing", new PartitionKey("user"), null, It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesImageCleanupIndexEntry()
+    {
+        var (sut, _, wardrobeContainer, cleanupContainer) = CreateRepositoryWithImageIndex();
+
+        wardrobeContainer
+            .Setup(c => c.DeleteItemAsync<ClothingItem>(
+                "to-delete",
+                new PartitionKey("user"),
+                null,
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(
+                CosmosTestHelpers.CreateItemResponse(new ClothingItem { Id = "to-delete", UserId = "user" }).Object));
+        cleanupContainer
+            .Setup(c => c.DeleteItemAsync<WardrobeRepository.ClothingImageCleanupIndexEntry>(
+                "user:to-delete",
+                new PartitionKey(WardrobeImageCleanupIndex.PartitionKeyValue),
+                null,
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(
+                CosmosTestHelpers.CreateItemResponse(new WardrobeRepository.ClothingImageCleanupIndexEntry
+                {
+                    Id = "user:to-delete",
+                    ItemId = "to-delete",
+                    UserId = "user",
+                    Partition = WardrobeImageCleanupIndex.PartitionKeyValue,
+                }).Object));
+
+        await sut.DeleteAsync("to-delete", "user", CancellationToken.None);
+
+        cleanupContainer.Invocations.ShouldContain(i => i.Method.Name == nameof(Container.DeleteItemAsync));
     }
 
     [Fact]

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -233,6 +233,23 @@ resource "azurerm_cosmosdb_sql_container" "wardrobe" {
   }
 }
 
+resource "azurerm_cosmosdb_sql_container" "wardrobe_image_cleanup_index" {
+  name                  = "WardrobeImageCleanupIndex"
+  resource_group_name   = azurerm_resource_group.rg_pluckit_archive.name
+  account_name          = azurerm_cosmosdb_account.pluckit.name
+  database_name         = azurerm_cosmosdb_sql_database.pluckit.name
+  partition_key_paths   = ["/partition"]
+  partition_key_version = 1
+
+  indexing_policy {
+    indexing_mode = "consistent"
+
+    included_path {
+      path = "/*"
+    }
+  }
+}
+
 # Stores refresh/access/ID tokens used for mobile auth session exchange.
 resource "azurerm_cosmosdb_sql_container" "refresh_tokens" {
   name                  = "RefreshTokens"
@@ -801,6 +818,7 @@ resource "azurerm_function_app_flex_consumption" "pluckit_api" {
     "Cosmos__Key"                           = azurerm_cosmosdb_account.pluckit.primary_key
     "Cosmos__Database"                      = azurerm_cosmosdb_sql_database.pluckit.name
     "Cosmos__Container"                     = azurerm_cosmosdb_sql_container.wardrobe.name
+    "Cosmos__ImageCleanupIndexContainer"    = azurerm_cosmosdb_sql_container.wardrobe_image_cleanup_index.name
     "Cosmos__RefreshTokensContainer"        = azurerm_cosmosdb_sql_container.refresh_tokens.name
     "Cosmos__WearEventsContainer"           = azurerm_cosmosdb_sql_container.wear_events.name
     "Cosmos__StylingActivityContainer"      = azurerm_cosmosdb_sql_container.styling_activity.name

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -33,6 +33,11 @@ output "cosmos_container_name" {
   value       = azurerm_cosmosdb_sql_container.wardrobe.name
 }
 
+output "cosmos_image_cleanup_index_container_name" {
+  description = "Cosmos DB container name for wardrobe image cleanup index."
+  value       = azurerm_cosmosdb_sql_container.wardrobe_image_cleanup_index.name
+}
+
 output "cosmos_vault_insights_cache_container_name" {
   description = "Cosmos DB container name for cached vault insight responses."
   value       = azurerm_cosmosdb_sql_container.vault_insights_cache.name

--- a/scripts/setup-local-cosmos.py
+++ b/scripts/setup-local-cosmos.py
@@ -33,6 +33,7 @@ DATABASE = "PluckIt"
 
 CONTAINERS = [
     ("Wardrobe",                      _PK_USER),
+    ("WardrobeImageCleanupIndex",      "/partition"),
     ("UserProfiles",                  "/id"),
     ("Conversations",                 _PK_USER),
     ("Digests",                       _PK_USER),


### PR DESCRIPTION
- Introduced a new Cosmos DB container for image cleanup indexing, enhancing the wardrobe management system.
- Updated the `WardrobeRepository` to support syncing and deleting entries in the image cleanup index.
- Modified `CleanupFunctions` to utilize the new index for identifying known item IDs.
- Enhanced local settings and infrastructure scripts to accommodate the new container.
- Added unit tests to ensure correct behavior of the image cleanup index operations.

Closes #74 