### PR TITLE
Fix issue #59: validate LLM clothing category

### DIFF
--- a/PluckIt.Infrastructure/ClothingMetadataService.cs
+++ b/PluckIt.Infrastructure/ClothingMetadataService.cs
@@ -5,6 +5,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.AI.OpenAI;
 using OpenAI.Chat;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using PluckIt.Core;
 
 namespace PluckIt.Infrastructure;
@@ -12,13 +14,30 @@ namespace PluckIt.Infrastructure;
 public class ClothingMetadataService : IClothingMetadataService
 {
   private readonly ChatClient _chatClient;
+  private readonly ILogger<ClothingMetadataService> _logger;
+  private const string UncategorisedCategory = "Uncategorised";
 
   public ClothingMetadataService(AzureOpenAIClient client, string deploymentName)
+    : this(client, deploymentName, NullLogger<ClothingMetadataService>.Instance)
+  {
+  }
+
+  public ClothingMetadataService(
+    AzureOpenAIClient client,
+    string deploymentName,
+    ILogger<ClothingMetadataService>? logger)
   {
     if (client is null) throw new ArgumentNullException(nameof(client));
     if (deploymentName is null) throw new ArgumentNullException(nameof(deploymentName));
     _chatClient = client.GetChatClient(deploymentName);
+    _logger = logger ?? NullLogger<ClothingMetadataService>.Instance;
   }
+
+  private static readonly HashSet<string> _allowedCategories = new(StringComparer.OrdinalIgnoreCase)
+  {
+    "Tops", "Bottoms", "Outerwear", "Footwear", "Accessories",
+    "Knitwear", "Dresses", "Activewear", "Swimwear", "Underwear",
+  };
 
   // Azure OpenAI vision only accepts these four MIME types.
   private static readonly HashSet<string> _supportedMediaTypes = new(StringComparer.OrdinalIgnoreCase)
@@ -35,7 +54,8 @@ public class ClothingMetadataService : IClothingMetadataService
     {
       var raw = await FetchMetadataTextAsync(imageData, mediaType, cancellationToken);
       var normalized = StripCodeFence(raw);
-      return ParseMetadata(normalized);
+      var metadata = ParseMetadata(normalized);
+      return EnsureAllowedCategory(metadata);
     }
     catch
     {
@@ -90,6 +110,22 @@ public class ClothingMetadataService : IClothingMetadataService
       ReadTags(root),
       ReadColours(root));
   }
+
+  private ClothingMetadata EnsureAllowedCategory(ClothingMetadata metadata)
+  {
+    if (IsCategoryAllowed(metadata.Category))
+      return metadata;
+
+    _logger.LogWarning(
+      "LLM returned unexpected category '{Category}'. Falling back to {FallbackCategory}.",
+      metadata.Category ?? "<null>",
+      UncategorisedCategory);
+
+    return metadata with { Category = UncategorisedCategory };
+  }
+
+  private static bool IsCategoryAllowed(string? category) =>
+    _allowedCategories.Contains(category ?? string.Empty);
 
   private static string? GetOptionalString(JsonElement root, string propertyName)
   {

--- a/PluckIt.Tests/Unit/Infrastructure/ClothingMetadataServiceTests.cs
+++ b/PluckIt.Tests/Unit/Infrastructure/ClothingMetadataServiceTests.cs
@@ -158,6 +158,41 @@ public sealed class ClothingMetadataServiceTests
     }
 
     [Fact]
+    public async Task ExtractMetadataAsync_MapsInvalidCategoryToUncategorised()
+    {
+        const string json = """
+            ```json
+            {
+              "brand": "Acme",
+              "category": "T-Shirt",
+              "tags": ["cotton", "layered"],
+              "colours": [{ "name": "White", "hex": "#FFFFFF" }]
+            }
+            ```
+            """;
+
+        var chatClient = new Mock<ChatClient>(MockBehavior.Strict);
+        chatClient
+            .Setup(c => c.CompleteChatAsync(
+                It.IsAny<ChatMessage[]>(),
+                It.IsAny<ChatCompletionOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OpenAiTestHelpers.CreateChatCompletionResult(json));
+
+        var openAi = new Mock<AzureOpenAIClient>(MockBehavior.Strict);
+        openAi
+            .Setup(c => c.GetChatClient("test-deployment"))
+            .Returns(chatClient.Object);
+
+        var sut = new ClothingMetadataService(openAi.Object, "test-deployment");
+        var imageData = BinaryData.FromString("image bytes");
+
+        var actual = await sut.ExtractMetadataAsync(imageData, "image/jpeg", CancellationToken.None);
+
+        actual.Category.ShouldBe("Uncategorised");
+    }
+
+    [Fact]
     public async Task ExtractMetadataAsync_UnsupportedMediaTypeReturnsEmptyMetadata()
     {
         var openAi = new Mock<AzureOpenAIClient>();


### PR DESCRIPTION
## Summary
- Issue: https://github.com/AB-Law/Pluck-It/issues/59
- Branch: bugfix/59-clothingmetadataservice-cs-llm-returned-category-not-validated-invalid-values-persist-silently

## What changed
- Added explicit allowed-category validation in `ClothingMetadataService` after LLM metadata parse.
- Invalid or null category values are normalized to `Uncategorised` and emitted as a warning log.
- Extended `ClothingMetadataServiceTests` with coverage for invalid category fallback behavior.

## Validation
- Build: `dotnet build PluckIt.sln` ✅ pass
- Tests: `dotnet test PluckIt.sln --filter "FullyQualifiedName~ClothingMetadataServiceTests"` ✅ pass

## Files changed
- PluckIt.Infrastructure/ClothingMetadataService.cs
- PluckIt.Tests/Unit/Infrastructure/ClothingMetadataServiceTests.cs

## Wiki sync
- Wiki path used: /Users/akshayb/projects/Pluck-It.wiki
- Updated files: pending