### PR TITLE
Fix: paginate digest profile reads

### DIFF
--- a/PluckIt.Processor/agents/digest_agent.py
+++ b/PluckIt.Processor/agents/digest_agent.py
@@ -354,12 +354,15 @@ def run_weekly_digest() -> None:
 
     try:
         profile_container = get_user_profiles_container_sync()
-        all_profiles = list(profile_container.read_all_items())
+        profiles_cursor = profile_container.query_items(
+            query="SELECT c.id FROM c",
+            max_item_count=500,
+        )
     except Exception as exc:
         logger.error("Digest: failed to list profiles: %s", exc)
         return
 
-    for profile in all_profiles:
+    for profile in profiles_cursor:
         user_id = profile.get("id")
         if not user_id:
             continue

--- a/PluckIt.Processor/tests/unit/test_digest_agent.py
+++ b/PluckIt.Processor/tests/unit/test_digest_agent.py
@@ -247,14 +247,16 @@ def test_save_digest_and_update_profile_updates_fingerprint():
 
 @pytest.mark.unit
 def test_run_weekly_digest_tracks_outcomes_and_handles_failures():
-    read_all_profiles = MagicMock(return_value=[
+    read_profiles = MagicMock(
+        return_value=iter([
         {"id": "user-good"},
         {"id": "user-bad"},
         {"id": ""},
         {},
     ])
+    )
     profile_container = MagicMock()
-    profile_container.read_all_items = read_all_profiles
+    profile_container.query_items = read_profiles
 
     def _run_digest_side_effect(user_id: str):
         if user_id == "user-bad":
@@ -271,6 +273,7 @@ def test_run_weekly_digest_tracks_outcomes_and_handles_failures():
     assert mock_info.call_count >= 2
     last_call = mock_info.call_args_list[-1]
     assert "Weekly digest complete" in last_call.args[0]
+    read_profiles.assert_called_once_with(query="SELECT c.id FROM c", max_item_count=500)
 @pytest.mark.unit
 def test_run_digest_for_user_with_status_fails_when_no_suggestions():
     profile_container = MagicMock()


### PR DESCRIPTION
## Summary
- Issue: https://github.com/AB-Law/Pluck-It/issues/57
- Branch: bugfix/57-digest-agent-load-all-profiles-pagination

## What changed
- Updated \`run_weekly_digest()\` in \`PluckIt.Processor/agents/digest_agent.py\` to use a paginated query cursor instead of \`list(profile_container.read_all_items())\`.
- Switched to `query="SELECT c.id FROM c"` with `max_item_count=500` and process profiles in a streaming loop.
- Extended \`test_run_weekly_digest_tracks_outcomes_and_handles_failures\` in \`PluckIt.Processor/tests/unit/test_digest_agent.py\` to mock `query_items` and assert paginated query usage.

## Validation
- Build: n/a (Python module; no dedicated build step in this repo)
- Tests: `cd /Users/akshayb/projects/Pluck-It-issue-57-digest-agent-load-all-profiles-pagination/PluckIt.Processor && python -m pytest tests/unit/test_digest_agent.py -v --tb=short -m unit` ✅ pass
- Tests: `cd /Users/akshayb/projects/Pluck-It-issue-57-digest-agent-load-all-profiles-pagination/PluckIt.Processor && python -m pytest tests/unit/ -v --tb=short -m unit` ✅ pass

## Files changed
- PluckIt.Processor/agents/digest_agent.py
- PluckIt.Processor/tests/unit/test_digest_agent.py