### PR TITLE
Batch canonicalize mood embeddings in mood processor

### DIFF
--- a/PluckIt.Processor/agents/mood_processor.py
+++ b/PluckIt.Processor/agents/mood_processor.py
@@ -498,8 +498,9 @@ def run_from_snippets(snippets: list[dict]) -> int:
         for p in unique_primaries
     }
 
-    saved = 0
-    for mood_data, name_embedding in zip(deduped, embeddings):
+    canonicalized_indices: list[int] = []
+    canonicalized_names: list[str] = []
+    for idx, (mood_data, name_embedding) in enumerate(zip(deduped, embeddings)):
         primary = mood_data.get("primaryMood", "")
         if primary not in PRIMARY_MOODS:
             logger.warning("Unknown primaryMood '%s' for '%s' - skipping.", primary, mood_data.get("name"))
@@ -511,11 +512,26 @@ def run_from_snippets(snippets: list[dict]) -> int:
         )
 
         if mood_data["name"] != original_name:
-            try:
-                name_embedding = embedder.embed_query(mood_data["name"])
-            except Exception as exc:
-                logger.debug("Re-embed after canonicalization failed: %s", exc)
+            canonicalized_indices.append(idx)
+            canonicalized_names.append(mood_data["name"])
 
+    if canonicalized_names:
+        try:
+            new_embeddings = embedder.embed_documents(canonicalized_names)
+            if len(new_embeddings) != len(canonicalized_indices):
+                logger.warning(
+                    "Canonicalized mood re-embed count mismatch: got %d embeddings for %d names.",
+                    len(new_embeddings),
+                    len(canonicalized_indices),
+                )
+            else:
+                for idx, name_embedding in zip(canonicalized_indices, new_embeddings):
+                    embeddings[idx] = name_embedding
+        except Exception as exc:
+            logger.debug("Batch re-embed after canonicalization failed: %s", exc)
+
+    saved = 0
+    for mood_data, name_embedding in zip(deduped, embeddings):
         try:
             upsert_mood(mood_data, name_embedding, container)
             saved += 1

--- a/PluckIt.Processor/tests/unit/test_mood_processor.py
+++ b/PluckIt.Processor/tests/unit/test_mood_processor.py
@@ -1,0 +1,120 @@
+"""Unit tests for mood processor canonicalization embedding behavior."""
+
+from unittest.mock import MagicMock, patch
+
+from agents import mood_processor
+
+
+def test_run_from_snippets_batches_reembed_calls_for_canonicalized_names() -> None:
+    moods = [
+        {
+            "name": "Quiet Luxury",
+            "primaryMood": "Minimalist",
+            "resolvedSources": [{"url": "https://example.com/a"}],
+        },
+        {
+            "name": "Street Utility",
+            "primaryMood": "Streetwear",
+            "resolvedSources": [{"url": "https://example.com/b"}],
+        },
+    ]
+    initial_embeddings = [[0.9], [0.1]]
+
+    embedder = MagicMock()
+    embedder.embed_documents.return_value = [[0.2]]
+
+    with patch("agents.mood_processor._build_llm", return_value=MagicMock()), \
+            patch("agents.mood_processor._build_confirm_llm", return_value=MagicMock()), \
+            patch("agents.mood_processor._build_embedder", return_value=embedder), \
+            patch("agents.mood_processor.get_moods_container_sync", return_value=MagicMock()), \
+            patch("agents.mood_processor._extract_all_parallel", return_value=moods), \
+            patch("agents.mood_processor._dedup_within_run", return_value=(moods, initial_embeddings)), \
+            patch("agents.mood_processor._load_existing_moods_with_embeddings", return_value=[]), \
+            patch(
+                "agents.mood_processor._canonicalize_against_db",
+                side_effect=lambda mood, *_args, **_kwargs: _canonicalize_name(mood),
+            ), \
+            patch("agents.mood_processor.upsert_mood") as upsert_mood:
+        result = mood_processor.run_from_snippets([{"title": "a", "summary": "", "url": "u", "published": "", "source": "r"}])
+
+    assert result == 2
+    embedder.embed_documents.assert_called_once_with(["Modern Luxury"])
+    embedder.embed_query.assert_not_called()
+
+    first_saved = upsert_mood.call_args_list[0].args
+    second_saved = upsert_mood.call_args_list[1].args
+    assert first_saved[1] == [0.2]
+    assert second_saved[1] == [0.1]
+    assert first_saved[0]["name"] == "Modern Luxury"
+    assert second_saved[0]["name"] == "Street Utility"
+
+
+def _canonicalize_name(mood: dict, *_args, **_kwargs) -> dict:
+    if mood["name"] == "Quiet Luxury":
+        mood["name"] = "Modern Luxury"
+    return mood
+
+
+def test_run_from_snippets_falls_back_to_original_embeddings_on_reembed_failure() -> None:
+    moods = [
+        {
+            "name": "Quiet Luxury",
+            "primaryMood": "Minimalist",
+            "resolvedSources": [{"url": "https://example.com/a"}],
+        },
+        {
+            "name": "Street Utility",
+            "primaryMood": "Streetwear",
+            "resolvedSources": [{"url": "https://example.com/b"}],
+        },
+    ]
+    initial_embeddings = [[0.9], [0.1]]
+
+    embedder = MagicMock()
+    embedder.embed_documents.side_effect = [RuntimeError("embeddings unavailable")]
+
+    with patch("agents.mood_processor._build_llm", return_value=MagicMock()), \
+            patch("agents.mood_processor._build_confirm_llm", return_value=MagicMock()), \
+            patch("agents.mood_processor._build_embedder", return_value=embedder), \
+            patch("agents.mood_processor.get_moods_container_sync", return_value=MagicMock()), \
+            patch("agents.mood_processor._extract_all_parallel", return_value=moods), \
+            patch("agents.mood_processor._dedup_within_run", return_value=(moods, initial_embeddings)), \
+            patch("agents.mood_processor._load_existing_moods_with_embeddings", return_value=[]), \
+            patch("agents.mood_processor._canonicalize_against_db", side_effect=_canonicalize_name), \
+            patch("agents.mood_processor.upsert_mood") as upsert_mood:
+        result = mood_processor.run_from_snippets([{"title": "a", "summary": "", "url": "u", "published": "", "source": "r"}])
+
+    assert result == 2
+    embedder.embed_documents.assert_called_once_with(["Modern Luxury"])
+    assert upsert_mood.call_args_list[0].args[1] == [0.9]
+    assert upsert_mood.call_args_list[1].args[1] == [0.1]
+
+
+def test_run_from_snippets_does_not_reembed_if_not_canonicalized() -> None:
+    moods = [
+        {
+            "name": "Quiet Luxury",
+            "primaryMood": "Minimalist",
+            "resolvedSources": [{"url": "https://example.com/a"}],
+        },
+    ]
+    initial_embeddings = [[0.9]]
+
+    embedder = MagicMock()
+
+    with patch("agents.mood_processor._build_llm", return_value=MagicMock()), \
+            patch("agents.mood_processor._build_confirm_llm", return_value=MagicMock()), \
+            patch("agents.mood_processor._build_embedder", return_value=embedder), \
+            patch("agents.mood_processor.get_moods_container_sync", return_value=MagicMock()), \
+            patch("agents.mood_processor._extract_all_parallel", return_value=moods), \
+            patch("agents.mood_processor._dedup_within_run", return_value=(moods, initial_embeddings)), \
+            patch("agents.mood_processor._load_existing_moods_with_embeddings", return_value=[]), \
+            patch(
+                "agents.mood_processor._canonicalize_against_db",
+                side_effect=lambda mood, *_args, **_kwargs: mood,
+            ), \
+            patch("agents.mood_processor.upsert_mood"):
+        result = mood_processor.run_from_snippets([{"title": "a", "summary": "", "url": "u", "published": "", "source": "r"}])
+
+    assert result == 1
+    embedder.embed_documents.assert_not_called()


### PR DESCRIPTION
## Summary
- Fixes #58 by batching re-embeddings for canonicalized moods in `agents/mood_processor.py::run_from_snippets`.
- Replaces per-mood `embedder.embed_query(...)` calls with one batched `embedder.embed_documents(...)` for canonicalized names.
- Keeps previous embeddings when batch re-embedding fails or returns unexpected cardinality.
- Adds unit coverage for batched re-embedding, failure fallback, and no-change behavior.

## Issue
- https://github.com/AB-Law/Pluck-It/issues/58

## Validation
- `python -m compileall -q agents`
- `python -m pytest tests/unit/test_mood_processor.py -v --tb=short`
- `python -m pytest tests/unit/ -v --tb=short --maxfail=1`