### PR TITLE
bugfix: clamp WearHistoryRepository maxResults

### DIFF
--- a/PluckIt.Infrastructure/WearHistoryRepository.cs
+++ b/PluckIt.Infrastructure/WearHistoryRepository.cs
@@ -31,6 +31,8 @@ public class WearHistoryRepository : IWearHistoryRepository
     int maxResults = 366,
     CancellationToken cancellationToken = default)
   {
+    var safeMaxResults = Math.Clamp(maxResults, 1, 1000);
+
     var sql = "SELECT * FROM c WHERE c.userId = @userId AND c.itemId = @itemId";
     if (from.HasValue) sql += " AND c.occurredAt >= @from";
     if (to.HasValue) sql += " AND c.occurredAt <= @to";
@@ -48,16 +50,16 @@ public class WearHistoryRepository : IWearHistoryRepository
       requestOptions: new QueryRequestOptions
       {
         PartitionKey = new PartitionKey(userId),
-        MaxItemCount = Math.Clamp(maxResults, 1, 1000),
+        MaxItemCount = safeMaxResults,
       });
 
-    while (iterator.HasMoreResults && results.Count < maxResults)
+    while (iterator.HasMoreResults && results.Count < safeMaxResults)
     {
       var page = await iterator.ReadNextAsync(cancellationToken);
       results.AddRange(page);
     }
 
-    return results.Take(maxResults).ToList();
+    return results.Take(safeMaxResults).ToList();
   }
 }
 

--- a/PluckIt.Tests/Unit/Infrastructure/WearHistoryRepositoryTests.cs
+++ b/PluckIt.Tests/Unit/Infrastructure/WearHistoryRepositoryTests.cs
@@ -140,4 +140,27 @@ public sealed class WearHistoryRepositoryTests
         queryOptions.ShouldNotBeNull();
         queryOptions!.MaxItemCount.ShouldBe(1);
     }
+
+  [Fact]
+  public async Task GetByItemAsync_StopsFetchingAtClampedMaxResults()
+  {
+    var events = Enumerable.Range(1, 1100)
+      .Select(i => Record($"h{i}", "item", "user"))
+      .ToArray();
+    var iterator = CosmosTestHelpers.CreateQueryIterator(
+      (events.Take(1000).ToArray(), "token-2"),
+      (events.Skip(1000).ToArray(), null));
+    QueryRequestOptions? queryOptions = null;
+
+    _mockContainer
+      .Setup(c => c.GetItemQueryIterator<WearHistoryRecord>(It.IsAny<QueryDefinition>(), It.IsAny<string>(), It.IsAny<QueryRequestOptions>()))
+      .Callback((QueryDefinition _, string _, QueryRequestOptions options) => queryOptions = options)
+      .Returns(iterator.Object);
+
+    var actual = await _sut.GetByItemAsync("item", "user", maxResults: 2000, cancellationToken: CancellationToken.None);
+
+    actual.Count.ShouldBe(1000);
+    queryOptions.ShouldNotBeNull();
+    queryOptions!.MaxItemCount.ShouldBe(1000);
+  }
 }


### PR DESCRIPTION
## Summary
- Issue: https://github.com/AB-Law/Pluck-It/issues/66
- Branch: bugfix/66-wearhistoryrepository-cs-maxresults-parameter-has-no-server-side-cap-client-can-trigger-ru-spike

## What changed
- Added repository-level clamping for `maxResults` in `WearHistoryRepository.GetByItemAsync()`.
- Reused the clamped value for query `MaxItemCount`, loop termination, and final result slicing to prevent unbounded reads.
- Added/updated unit tests covering clamp boundaries and oversized `maxResults` stop behavior.

## Validation
- `dotnet build PluckIt.sln` ✅ pass
- `dotnet test PluckIt.Tests/PluckIt.Tests.csproj --filter "FullyQualifiedName~WearHistoryRepositoryTests"` ✅ pass
- `dotnet test PluckIt.Tests/PluckIt.Tests.csproj --filter "FullyQualifiedName~PluckIt.Tests.Unit.Infrastructure"` ✅ pass

## Files changed
- `PluckIt.Infrastructure/WearHistoryRepository.cs`
- `PluckIt.Tests/Unit/Infrastructure/WearHistoryRepositoryTests.cs`

## Wiki sync
- Wiki path used: ../Pluck-It.wiki
