### PR TITLE
feat: Enhance traceability and metadata handling in function_app and …

### DIFF
--- a/PluckIt.Processor/agents/digest_agent.py
+++ b/PluckIt.Processor/agents/digest_agent.py
@@ -24,8 +24,9 @@ import json
 import logging
 import os
 from collections import Counter
+import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import AzureChatOpenAI
@@ -44,6 +45,42 @@ _PROMPT_ITEM_LIMIT = 50
 _DigestOutcome = Literal["skipped_by_hash", "skipped_by_opt_out", "generated", "failed"]
 
 
+def _build_digest_langfuse_callbacks(trace_id: str | None = None, *, user_id: str | None = None) -> list[Any]:
+    """Build optional Langfuse callbacks using function_app shared settings."""
+    try:
+        from function_app import _build_langfuse_callbacks as shared_build
+    except Exception as exc:
+        logger.warning("Digest: unable to import shared Langfuse callback builder: %s", exc)
+        return []
+
+    try:
+        return shared_build(
+            trace_id,
+            user_id=user_id,
+            metadata={"component": "digest", "trace_label": "wardrobe-digest"},
+        )
+    except Exception as exc:
+        logger.warning("Digest: shared Langfuse callback builder failed: %s", exc)
+        return []
+
+
+def _flush_digest_langfuse_callbacks(callbacks: list[Any]) -> None:
+    """Flush optional Langfuse callbacks if available."""
+    if not callbacks:
+        return
+
+    try:
+        from function_app import _flush_langfuse_callbacks as shared_flush
+    except Exception as exc:
+        logger.warning("Digest: unable to import shared Langfuse callback flusher: %s", exc)
+        return
+
+    try:
+        shared_flush(callbacks)
+    except Exception as exc:
+        logger.warning("Digest: shared Langfuse callback flush failed: %s", exc)
+
+
 def _get_env(name: str, default: Optional[str] = None) -> str:
     v = os.getenv(name, default)
     if v is None:
@@ -57,15 +94,30 @@ def compute_wardrobe_hash(item_ids: list[str]) -> str:
     return hashlib.sha256(combined.encode()).hexdigest()[:16]
 
 
-def _build_digest_llm() -> AzureChatOpenAI:
-    return AzureChatOpenAI(
-        azure_endpoint=_get_env("AZURE_OPENAI_ENDPOINT"),
-        api_key=_get_env("AZURE_OPENAI_API_KEY"),
-        azure_deployment=_get_env("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1-mini"),
-        api_version="2024-12-01-preview",
-        temperature=0.5,
-        max_tokens=800,
-    )
+def _build_digest_llm(
+    *,
+    trace_id: str | None = None,
+    user_id: str | None = None,
+    callbacks: list[Any] | None = None,
+    azure_deployment: str | None = None,
+    temperature: float = 0.5,
+    max_tokens: int = 800,
+) -> AzureChatOpenAI:
+    """Build the digest LLM client."""
+    if callbacks is None:
+        callbacks = _build_digest_langfuse_callbacks(trace_id, user_id=user_id)
+
+    llm_kwargs = {
+        "azure_endpoint": _get_env("AZURE_OPENAI_ENDPOINT"),
+        "api_key": _get_env("AZURE_OPENAI_API_KEY"),
+        "azure_deployment": azure_deployment or _get_env("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1-mini"),
+        "api_version": "2024-12-01-preview",
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+    }
+    if callbacks:
+        llm_kwargs["callbacks"] = callbacks
+    return AzureChatOpenAI(**llm_kwargs)
 
 
 def _recency_score(wear_count: int, last_worn_at: Optional[str]) -> float:
@@ -83,7 +135,14 @@ def _recency_score(wear_count: int, last_worn_at: Optional[str]) -> float:
     return round(wear_count * recency, 3)
 
 
-def _infer_climate_zone(location_city: Optional[str], wear_events_conditions: list[str]) -> Optional[str]:
+def _infer_climate_zone(
+    location_city: Optional[str],
+    wear_events_conditions: list[str],
+    *,
+    callbacks: list[Any] | None = None,
+    trace_id: str | None = None,
+    user_id: str | None = None,
+) -> Optional[str]:
     """
     Best-effort climate zone inference from city name + wear-event weather snapshots.
     Uses a nano-LLM call; returns None on any failure (non-blocking).
@@ -99,14 +158,16 @@ def _infer_climate_zone(location_city: Optional[str], wear_events_conditions: li
             "Reply with ONE word — the climate zone: temperate | tropical | continental | arid | polar. "
             "No explanation."
         )
-        nano = AzureChatOpenAI(
-            azure_endpoint=_get_env("AZURE_OPENAI_ENDPOINT"),
-            api_key=_get_env("AZURE_OPENAI_API_KEY"),
-            azure_deployment=os.getenv("AZURE_OPENAI_NANO_DEPLOYMENT",
-                                        os.getenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1-mini")),
-            api_version="2024-12-01-preview",
+        nano = _build_digest_llm(
+            trace_id=trace_id,
+            user_id=user_id,
+            callbacks=callbacks,
             temperature=0,
             max_tokens=5,
+            azure_deployment=os.getenv(
+                "AZURE_OPENAI_NANO_DEPLOYMENT",
+                os.getenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1-mini"),
+            ),
         )
         result = nano.invoke(prompt).content.strip().lower()
         if result in {"temperate", "tropical", "continental", "arid", "polar"}:
@@ -116,16 +177,24 @@ def _infer_climate_zone(location_city: Optional[str], wear_events_conditions: li
     return None
 
 
-def run_digest_for_user(user_id: str, force: bool = False) -> Optional[dict]:
+def run_digest_for_user(
+    user_id: str,
+    force: bool = False,
+    trace_id: str | None = None,
+) -> Optional[dict]:
     """
     Synchronous digest run for a single user. Returns the digest dict or None
     if skipped (wardrobe unchanged) or on error.
     """
-    result, _ = run_digest_for_user_with_status(user_id, force=force)
+    result, _ = run_digest_for_user_with_status(user_id, force=force, trace_id=trace_id)
     return result
 
 
-def run_digest_for_user_with_status(user_id: str, force: bool = False) -> tuple[Optional[dict], _DigestOutcome]:
+def run_digest_for_user_with_status(
+    user_id: str,
+    force: bool = False,
+    trace_id: str | None = None,
+) -> tuple[Optional[dict], _DigestOutcome]:
     """
     Same as `run_digest_for_user`, plus internal status for scheduler metrics.
 
@@ -158,15 +227,30 @@ def run_digest_for_user_with_status(user_id: str, force: bool = False) -> tuple[
     liked, disliked = _load_recent_feedback(user_id)
     
     climate_zone = profile.get("climateZone")
-    if not climate_zone and profile.get("locationCity"):
-        climate_zone = _infer_climate_zone(profile["locationCity"], climate_signals)
+    trace_id = trace_id or str(uuid.uuid4())
+    callbacks = _build_digest_langfuse_callbacks(trace_id, user_id=user_id)
+    suggestions: list = []
+    try:
+        if not climate_zone and profile.get("locationCity"):
+            climate_zone = _infer_climate_zone(
+                profile["locationCity"],
+                climate_signals,
+                callbacks=callbacks,
+                trace_id=trace_id,
+                user_id=user_id,
+            )
 
-    # 4. Generate Suggestions via LLM
-    items_with_history = sum(1 for s in ranked_items if s["wearCount"] > 0)
-    suggestions = _generate_suggestions(
-        profile, ranked_items, category_counts, liked, disliked,
-        climate_zone, items_with_history, len(wardrobe_data["item_ids"])
-    )
+        # 4. Generate Suggestions via LLM
+        items_with_history = sum(1 for s in ranked_items if s["wearCount"] > 0)
+        suggestions = _generate_suggestions(
+            profile, ranked_items, category_counts, liked, disliked,
+            climate_zone, items_with_history, len(wardrobe_data["item_ids"]),
+            trace_id=trace_id,
+            user_id=user_id,
+            callbacks=callbacks,
+        )
+    finally:
+        _flush_digest_langfuse_callbacks(callbacks)
     if not suggestions:
         return None, "failed"
 
@@ -274,7 +358,20 @@ def _load_recent_feedback(user_id: str) -> tuple[list[str], list[str]]:
         pass
     return liked, disliked
 
-def _generate_suggestions(profile, scored, counts, liked, disliked, climate, worn_count, total_count) -> list:
+def _generate_suggestions(
+    profile,
+    scored,
+    counts,
+    liked,
+    disliked,
+    climate,
+    worn_count,
+    total_count,
+    *,
+    trace_id: str | None = None,
+    user_id: str | None = None,
+    callbacks: list[Any] | None = None,
+) -> list:
     try:
         sparse = worn_count < 5
         style_prefs = profile.get("stylePreferences") or []
@@ -292,7 +389,11 @@ Top items: {json.dumps(scored[:20])}
 {sparse_note}{feedback_note}
 3-5 purchase suggestions (item, rationale) in JSON array format."""
 
-        llm = _build_digest_llm()
+        llm = _build_digest_llm(
+            trace_id=trace_id,
+            user_id=user_id,
+            callbacks=callbacks,
+        )
         resp = llm.invoke([SystemMessage(content="Stylist. JSON only."), HumanMessage(content=prompt)])
         raw = resp.content.strip()
         if raw.startswith("```"):

--- a/PluckIt.Processor/function_app.py
+++ b/PluckIt.Processor/function_app.py
@@ -963,6 +963,7 @@ def _metadata_api_key() -> str:
 def _metadata_request_id_from_headers(headers: dict[str, str], request: Request) -> str:
     return (
         _normalise_header_value(headers.get("x-request-id"))
+        or _normalise_header_value(headers.get("x-trace-id"))
         or _normalise_header_value(request.headers.get("X-Request-Id"))
         or ""
     )
@@ -1049,6 +1050,7 @@ def _set_trace_identifier_kwargs(
     *,
     trace_identifier: str | None,
     user_id: str | None,
+    extra_metadata: dict[str, Any] | None = None,
 ) -> None:
     has_user_id_arg = "user_id" in callback_signature.parameters
     has_metadata_arg = "metadata" in callback_signature.parameters
@@ -1060,7 +1062,11 @@ def _set_trace_identifier_kwargs(
     if supports_kwargs or has_user_id_arg:
         kwargs["user_id"] = user_id
     if supports_kwargs or has_metadata_arg:
-        kwargs["metadata"] = {"trace_id": trace_identifier}
+        metadata_payload = dict(extra_metadata or {})
+        if trace_identifier:
+            metadata_payload.setdefault("trace_id", trace_identifier)
+        if metadata_payload:
+            kwargs["metadata"] = metadata_payload
     if supports_kwargs or has_trace_context_arg:
         kwargs["trace_context"] = {"trace_id": trace_identifier}
 
@@ -1078,6 +1084,7 @@ def _build_langfuse_callback_kwargs(
     public_key: str,
     secret_key: str,
     host: str,
+    extra_metadata: dict[str, Any] | None = None,
     logger: Any,
 ) -> dict[str, Any]:
     supports_kwargs = any(
@@ -1097,6 +1104,7 @@ def _build_langfuse_callback_kwargs(
         supports_kwargs,
         trace_identifier=trace_identifier,
         user_id=user_id,
+        extra_metadata=extra_metadata,
     )
     if trace_identifier and not supports_kwargs:
         _warn_if_trace_context_unsupported(callback_signature, logger)
@@ -1119,7 +1127,12 @@ def _configure_langfuse_client(
     langfuse_cls(public_key=public_key, secret_key=secret_key)
 
 
-def _build_langfuse_callbacks(trace_id: str | None = None, *, user_id: str | None = None) -> list[Any]:
+def _build_langfuse_callbacks(
+    trace_id: str | None = None,
+    *,
+    user_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> list[Any]:
     """Build optional Langfuse callbacks for metadata extraction."""
     public_key = os.getenv("LANGFUSE_PUBLIC_KEY", "").strip()
     secret_key = os.getenv("LANGFUSE_SECRET_KEY", "").strip()
@@ -1152,6 +1165,7 @@ def _build_langfuse_callbacks(trace_id: str | None = None, *, user_id: str | Non
             public_key=public_key,
             secret_key=secret_key,
             host=host,
+            extra_metadata=metadata,
             logger=logger,
         )
         if not kwargs:
@@ -1461,7 +1475,11 @@ def _infer_clothing_metadata(
         if not endpoint or not api_key:
             raise RuntimeError("Azure OpenAI credentials are not configured.")
         langfuse_trace_id = _extract_langfuse_trace_id(request_id, traceparent)
-        callbacks = _build_langfuse_callbacks(langfuse_trace_id, user_id=item_id)
+        callbacks = _build_langfuse_callbacks(
+            langfuse_trace_id,
+            user_id=item_id,
+            metadata={"component": "clothing-metadata", "trace_label": "clothing-metadata"},
+        )
 
         llm = AzureChatOpenAI(
             azure_endpoint=endpoint,
@@ -2357,7 +2375,7 @@ async def update_memory(body: MemoryUpdateRequest, user_id: Annotated[str, Depen
         500: {"description": "Could not run digest."},
     },
 )
-async def run_digest_now(user_id: Annotated[str, Depends(get_user_id)], force: bool = True):
+async def run_digest_now(request: Request, user_id: Annotated[str, Depends(get_user_id)], force: bool = True):
     """Manually trigger digest generation for the authenticated user.
     Useful for local dev/testing — production relies on the Monday timer trigger.
     Defaults to force=True to bypass the wardrobe-unchanged hash guard.
@@ -2365,9 +2383,10 @@ async def run_digest_now(user_id: Annotated[str, Depends(get_user_id)], force: b
     """
     import asyncio
     from agents.digest_agent import run_digest_for_user
+    trace_id = request.headers.get("X-Trace-Id")
     try:
         result = await asyncio.get_event_loop().run_in_executor(
-            None, run_digest_for_user, user_id, force
+            None, run_digest_for_user, user_id, force, trace_id
         )
         if result is None:
             return {"status": "skipped", "reason": "opted out of recommendations or no wardrobe items"}

--- a/PluckIt.Processor/tests/unit/test_digest_agent.py
+++ b/PluckIt.Processor/tests/unit/test_digest_agent.py
@@ -6,10 +6,13 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 import hashlib
 import json
+from collections import Counter
 
 from agents.digest_agent import (
     _PROMPT_ITEM_LIMIT,
     _load_user_wardrobe,
+    _generate_suggestions,
+    _build_digest_langfuse_callbacks,
     _save_digest_and_update_profile,
     compute_wardrobe_hash,
     run_digest_for_user_with_status,
@@ -175,6 +178,95 @@ def test_run_digest_for_user_with_status_generates_digest():
 
     assert digest == {"id": "d-1"}
     assert outcome == "generated"
+
+
+@pytest.mark.unit
+def test_generate_suggestions_forwards_trace_context_to_llm_call():
+    fake_llm_response = MagicMock()
+    fake_llm_response.content = json.dumps(
+        [{"item": "White linen shirt", "reason": "Overwrites"}]
+    )
+    fake_llm = MagicMock()
+    fake_llm.invoke = MagicMock(return_value=fake_llm_response)
+
+    with patch("agents.digest_agent._build_digest_llm", return_value=fake_llm) as mock_build:
+        suggestions = _generate_suggestions(
+            {"stylePreferences": ["minimalist"], "preferredColours": ["navy"]},
+            [{"category": "tops"}],
+            Counter({"tops": 3}),
+            ["liked item"],
+            ["disliked item"],
+            "temperate",
+            1,
+            2,
+            trace_id="trace-123",
+            user_id="user-1",
+            callbacks=["cb-1"],
+        )
+
+    assert suggestions == [{"item": "White linen shirt", "rationale": "Overwrites"}]
+    mock_build.assert_called_once()
+    called_kwargs = mock_build.call_args.kwargs
+    assert called_kwargs["trace_id"] == "trace-123"
+    assert called_kwargs["user_id"] == "user-1"
+    assert called_kwargs["callbacks"] == ["cb-1"]
+
+
+@pytest.mark.unit
+def test_run_digest_for_user_with_status_builds_and_flushes_digest_callbacks():
+    profile_container = MagicMock()
+    profile_container.read_item.return_value = {
+        "id": "user-trace",
+        "wardrobeHashAtLastDigest": "old-hash",
+        "recommendationOptIn": True,
+        "climateZone": "temperate",
+    }
+    fake_callbacks = [MagicMock()]
+
+    with (
+        patch("agents.digest_agent.get_user_profiles_container_sync", return_value=profile_container),
+        patch("agents.digest_agent._load_user_wardrobe", return_value={"items": [{"wearCount": 1}], "item_ids": ["item-1"]}),
+        patch("agents.digest_agent.compute_wardrobe_hash", return_value="hash-456"),
+        patch("agents.digest_agent._should_skip_digest", return_value=False),
+        patch("agents.digest_agent._analyze_wardrobe", return_value=([], Counter({"tops": 1}), [])),
+        patch("agents.digest_agent._load_recent_feedback", return_value=([], [])),
+        patch("agents.digest_agent._build_digest_langfuse_callbacks", return_value=fake_callbacks) as mock_build,
+        patch("agents.digest_agent._generate_suggestions", return_value=[{"item": "jacket", "rationale": "works great"}]) as mock_generate,
+        patch("agents.digest_agent._compute_style_confidence", return_value=0.8),
+        patch("agents.digest_agent._create_digest_doc", return_value={"id": "d-1"}),
+        patch("agents.digest_agent._save_digest_and_update_profile", return_value=True),
+        patch("agents.digest_agent._flush_digest_langfuse_callbacks") as mock_flush,
+    ):
+        digest, outcome = run_digest_for_user_with_status("user-trace", force=True, trace_id="trace-123")
+
+    assert digest == {"id": "d-1"}
+    assert outcome == "generated"
+    mock_build.assert_called_once_with(
+        "trace-123",
+        user_id="user-trace",
+    )
+    mock_generate.assert_called_once()
+    generate_kwargs = mock_generate.call_args.kwargs
+    assert generate_kwargs["trace_id"] == "trace-123"
+    assert generate_kwargs["user_id"] == "user-trace"
+    assert generate_kwargs["callbacks"] == fake_callbacks
+    mock_flush.assert_called_once_with(fake_callbacks)
+
+
+@pytest.mark.unit
+def test_build_digest_langfuse_callbacks_forwards_component_label_to_shared_builder():
+    with patch("function_app._build_langfuse_callbacks") as mock_shared_build:
+        expected_callbacks = [MagicMock()]
+        mock_shared_build.return_value = expected_callbacks
+
+        callbacks = _build_digest_langfuse_callbacks("trace-123", user_id="user-trace")
+
+    assert callbacks == expected_callbacks
+    mock_shared_build.assert_called_once_with(
+        "trace-123",
+        user_id="user-trace",
+        metadata={"component": "digest", "trace_label": "wardrobe-digest"},
+    )
 
 
 @pytest.mark.unit

--- a/PluckIt.Processor/tests/unit/test_routes.py
+++ b/PluckIt.Processor/tests/unit/test_routes.py
@@ -17,7 +17,7 @@ import time
 from types import SimpleNamespace
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 from collections.abc import AsyncGenerator, AsyncIterator, Callable
-from function_app import _build_json_etag
+from function_app import _build_json_etag, _infer_clothing_metadata
 
 from fastapi import HTTPException
 import pytest
@@ -114,6 +114,69 @@ async def test_post_extract_metadata_forwards_trace_headers_to_infer(async_clien
     _, call_kwargs = mock_infer.call_args
     assert call_kwargs["request_id"] == "request-123"
     assert call_kwargs["traceparent"] == "00-11223344556677889900aabbccddeeff-1234567890abcdef-01"
+
+
+@pytest.mark.unit
+async def test_post_extract_metadata_forwards_x_trace_id_header_to_request_id(async_client):
+    async_image = base64.b64encode(b"fake-image").decode("ascii")
+    with patch("function_app._infer_clothing_metadata") as mock_infer:
+        mock_infer.return_value = {"brand": None, "category": None, "tags": [], "colours": []}
+        response = await async_client.post(
+            "/api/extract-clothing-metadata",
+            headers={"X-API-Key": "test-metadata-key", "X-Trace-Id": "trace-header-1"},
+            json={
+                "item_id": "item-1",
+                "image_bytes_base64": async_image,
+                "media_type": "image/jpeg",
+            },
+        )
+
+    assert response.status_code == 200
+    _, call_kwargs = mock_infer.call_args
+    assert call_kwargs["request_id"] == "trace-header-1"
+
+
+@pytest.mark.unit
+def test_infer_clothing_metadata_attaches_component_label_to_langfuse_metadata():
+    fake_llm_response = MagicMock()
+    fake_llm_response.content = json.dumps(
+        {"brand": "Acme", "category": "Outerwear", "tags": ["cotton"], "colours": [{"name": "Navy", "hex": "#001122"}]}
+    )
+    fake_llm = MagicMock()
+    fake_llm.invoke = MagicMock(return_value=fake_llm_response)
+
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "AZURE_OPENAI_ENDPOINT": "https://example.openai.azure.com/",
+                "AZURE_OPENAI_API_KEY": "test-key",
+                "AZURE_OPENAI_DEPLOYMENT": "gpt-4.1-mini",
+            },
+        ),
+        patch("function_app._build_langfuse_callbacks") as mock_build,
+        patch("langchain_openai.AzureChatOpenAI", return_value=fake_llm),
+    ):
+        result = _infer_clothing_metadata(
+            b"fake-image",
+            "image/jpeg",
+            "item-1",
+            request_id="request-123",
+        )
+
+    assert result["brand"] == "Acme"
+    assert result["category"] == "Outerwear"
+    assert result["tags"] == ["cotton"]
+    assert result["colours"] == [{"name": "Navy", "hex": "#001122"}]
+    mock_build.assert_called_once()
+    call_args, call_kwargs = mock_build.call_args
+    assert len(call_args) == 1
+    assert isinstance(call_args[0], str)
+    assert len(call_args[0]) == 32
+    assert call_kwargs == {
+        "user_id": "item-1",
+        "metadata": {"component": "clothing-metadata", "trace_label": "clothing-metadata"},
+    }
 
 
 @pytest.mark.unit
@@ -473,6 +536,18 @@ async def test_post_digest_run_returns_ok_on_success(async_client):
     data = response.json()
     assert data["status"] == "ok"
     assert "suggestions" in data["digest"]
+
+
+@pytest.mark.unit
+async def test_post_digest_run_forwards_x_trace_id(async_client):
+    with patch("agents.digest_agent.run_digest_for_user", return_value={"id": "digest-001", "suggestions": []}) as mock_run:
+        response = await async_client.post("/api/digest/run", headers={"X-Trace-Id": "digest-trace-header"})
+
+    assert response.status_code == 200
+    call_args, _ = mock_run.call_args
+    assert len(call_args) == 3
+    assert call_args[1] is True
+    assert call_args[2] == "digest-trace-header"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

We needed to add langfuse tracing to the digest feature.

## Changes

- Added support for extracting trace ID from headers in `_metadata_request_id_from_headers`.
- Updated `_set_trace_identifier_kwargs` to accept additional metadata and conditionally include it in the kwargs.
- Modified `_build_langfuse_callbacks` to accept metadata for improved context in callback generation.
- Enhanced `run_digest_now` to forward trace ID from the request headers.
- Introduced `_build_digest_langfuse_callbacks` in `digest_agent` for consistent metadata handling.
- Updated tests to verify trace ID propagation and metadata inclusion in LLM calls.


## Testing

<!-- List the commands you ran, or explain why tests were not run. -->

- [x] `dotnet test`
- [x] `pytest -m unit`
- [x] `npm test`
- [ ] `npm run test:e2e`
- [ ] Not applicable

## Checklist

- [x] PR targets `dev` (or `main` for release PRs)
- [x] Branch name follows project conventions (`feature/<name>` or `fix/<name>`)
- [x] Relevant tests pass for the areas changed
- [x] No `local.settings.json` files are committed
- [x] No credentials, keys, or secrets were added to code or comments
- [x] New environment variables are documented in the relevant `local.settings.json.example`
