### PR TITLE
Refactor shared token resolution for collection/stylist/auth flows

### DIFF
--- a/PluckIt.Functions/Auth/TokenResolver.cs
+++ b/PluckIt.Functions/Auth/TokenResolver.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace PluckIt.Functions.Auth;
+
+/// <summary>
+/// Resolves a user identifier from an incoming request using bearer token credentials.
+/// </summary>
+public interface ITokenResolver
+{
+    /// <summary>
+    /// Attempts to resolve the authenticated user id from the request's Authorization header.
+    /// Returns <c>null</c> when no valid identity can be extracted.
+    /// </summary>
+    Task<string?> ResolveUserIdAsync(HttpRequestData request, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Default implementation for resolving user ids from Google bearer tokens and refresh sessions.
+/// Falls back to <c>Local:DevUserId</c> when no Authorization header is present.
+/// </summary>
+public sealed class TokenResolver : ITokenResolver
+{
+    private const int TokenPrefixLength = 20;
+
+    private readonly Func<string, Task<string?>> _validateToken;
+    private readonly Func<string, CancellationToken, Task<string?>>? _resolveSessionUserId;
+    private readonly string? _localDevUserId;
+    private readonly ILogger<TokenResolver> _logger;
+
+    /// <summary>
+    /// Initializes a new token resolver from concrete runtime dependencies.
+    /// </summary>
+    public TokenResolver(
+        GoogleTokenValidator tokenValidator,
+        IConfiguration configuration,
+        ILogger<TokenResolver> logger,
+        RefreshSessionStore? refreshSessionStore = null)
+        : this(
+            tokenValidator.ValidateAsync,
+            refreshSessionStore is null ? null : refreshSessionStore.ResolveUserIdFromAccessTokenAsync,
+            configuration["Local:DevUserId"],
+            logger)
+    {
+    }
+
+    /// <summary>
+    /// Test-oriented constructor that accepts delegates for deterministic validation and session resolution.
+    /// </summary>
+    public TokenResolver(
+        Func<string, Task<string?>> validateTokenAsync,
+        Func<string, CancellationToken, Task<string?>>? resolveSessionUserIdAsync,
+        string? localDevUserId,
+        ILogger<TokenResolver> logger)
+    {
+        _validateToken = validateTokenAsync ?? throw new ArgumentNullException(nameof(validateTokenAsync));
+        _resolveSessionUserId = resolveSessionUserIdAsync;
+        _localDevUserId = localDevUserId;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Resolves a user id from a bearer token in the Authorization header, with graceful fallback.
+    /// </summary>
+    public async Task<string?> ResolveUserIdAsync(HttpRequestData request, CancellationToken cancellationToken)
+    {
+        if (!TryGetBearerToken(request, out var token))
+        {
+            return _localDevUserId;
+        }
+
+        string? userId = null;
+        try
+        {
+            userId = await _validateToken(token);
+            if (!string.IsNullOrWhiteSpace(userId))
+            {
+                return userId;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to validate access token. tokenPrefix={TokenPrefix}",
+                TruncateTokenPrefix(token));
+        }
+
+        if (_resolveSessionUserId is null)
+            return null;
+
+        try
+        {
+            return await _resolveSessionUserId(token, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to resolve user id from session token. tokenPrefix={TokenPrefix}",
+                TruncateTokenPrefix(token));
+            return null;
+        }
+    }
+
+    private static bool TryGetBearerToken(HttpRequestData request, out string token)
+    {
+        token = string.Empty;
+        if (!request.Headers.TryGetValues("Authorization", out var authHeaders))
+            return false;
+
+        var header = authHeaders.FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(header) || !header.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        token = header["Bearer ".Length..].Trim();
+        return !string.IsNullOrWhiteSpace(token);
+    }
+
+    private static string TruncateTokenPrefix(string token)
+    {
+        if (string.IsNullOrEmpty(token))
+            return "<empty>";
+        return token.Length <= TokenPrefixLength
+            ? token
+            : $"{token[..TokenPrefixLength]}...";
+    }
+}

--- a/PluckIt.Functions/Functions/AuthFunctions.cs
+++ b/PluckIt.Functions/Functions/AuthFunctions.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Text.Json;
-using System.Linq;
 using System.Threading;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -11,7 +10,10 @@ namespace PluckIt.Functions.Functions;
 /// <summary>
 /// Authentication exchange endpoints used by mobile clients.
 /// </summary>
-public class AuthFunctions(WardrobeFunctionsAuthContext authContext, RefreshSessionStore refreshSessionStore)
+public class AuthFunctions(
+    WardrobeFunctionsAuthContext authContext,
+    RefreshSessionStore refreshSessionStore,
+    ITokenResolver tokenResolver)
 {
     private const string ContentTypeHeader = "Content-Type";
     private const string JsonContentType = "application/json; charset=utf-8";
@@ -173,7 +175,7 @@ public class AuthFunctions(WardrobeFunctionsAuthContext authContext, RefreshSess
 
             if (!string.IsNullOrWhiteSpace(userId))
             {
-                var authenticatedUserId = await GetAuthenticatedUserIdFromRequestAsync(req, cancellationToken);
+                var authenticatedUserId = await tokenResolver.ResolveUserIdAsync(req, cancellationToken);
                 if (!string.Equals(authenticatedUserId, userId, StringComparison.Ordinal))
                     return await BuildJsonErrorResponse(req, HttpStatusCode.Forbidden, "Forbidden.");
 
@@ -255,45 +257,6 @@ public class AuthFunctions(WardrobeFunctionsAuthContext authContext, RefreshSess
         }
 
         return null;
-    }
-
-    private async Task<string?> GetAuthenticatedUserIdFromRequestAsync(HttpRequestData req, CancellationToken cancellationToken)
-    {
-        if (!req.Headers.TryGetValues("Authorization", out var authHeaders))
-            return null;
-
-        var header = authHeaders.FirstOrDefault();
-        if (string.IsNullOrWhiteSpace(header) || !header.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-            return null;
-
-        var token = header["Bearer ".Length..].Trim();
-        if (string.IsNullOrWhiteSpace(token))
-            return null;
-
-        string? googleUserId = null;
-        try
-        {
-            googleUserId = await authContext.TokenValidator.ValidateAsync(token);
-        }
-        catch (Exception)
-        {
-            // Ignore token validation failures here; callers can still resolve the user via refresh session fallback.
-        }
-
-        if (!string.IsNullOrWhiteSpace(googleUserId))
-            return googleUserId;
-
-        if (refreshSessionStore is null)
-            return null;
-
-        try
-        {
-            return await refreshSessionStore.ResolveUserIdFromAccessTokenAsync(token, cancellationToken);
-        }
-        catch
-        {
-            return null;
-        }
     }
 
     private static string? ResolveIdToken(JsonElement root)

--- a/PluckIt.Functions/Functions/CollectionFunctions.cs
+++ b/PluckIt.Functions/Functions/CollectionFunctions.cs
@@ -4,7 +4,6 @@ using System.Net;
 using System.Text.Json;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.Extensions.Configuration;
 using PluckIt.Core;
 using PluckIt.Functions.Auth;
 using PluckIt.Functions.Serialization;
@@ -18,9 +17,7 @@ namespace PluckIt.Functions.Functions;
 /// </summary>
 public class CollectionFunctions(
     ICollectionRepository repo,
-    GoogleTokenValidator tokenValidator,
-    IConfiguration config,
-    RefreshSessionStore? refreshSessionStore = null)
+    ITokenResolver tokenResolver)
 {
     // ── GET /api/collections ─────────────────────────────────────────────────
     // Returns owned collections + joined collections merged.
@@ -263,47 +260,8 @@ public class CollectionFunctions(
         HttpRequestData req,
         CancellationToken cancellationToken = default)
     {
-        if (TryGetBearerToken(req, out var token))
-        {
-            var sub = await tokenValidator.ValidateAsync(token);
-            if (sub is not null) return (true, sub);
-
-            var sessionUserId = await ResolveUserIdFromSessionTokenAsync(token, cancellationToken);
-            if (!string.IsNullOrWhiteSpace(sessionUserId))
-                return (true, sessionUserId);
-        }
-        var devId = config["Local:DevUserId"];
-        if (!string.IsNullOrEmpty(devId)) return (true, devId);
-        return (false, null);
-    }
-
-    private static bool TryGetBearerToken(HttpRequestData req, out string token)
-    {
-        token = string.Empty;
-        if (!req.Headers.TryGetValues("Authorization", out var authHeaders))
-            return false;
-
-        var header = authHeaders.FirstOrDefault();
-        if (string.IsNullOrWhiteSpace(header) || !header.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        token = header["Bearer ".Length..].Trim();
-        return !string.IsNullOrWhiteSpace(token);
-    }
-
-    private async Task<string?> ResolveUserIdFromSessionTokenAsync(string token, CancellationToken cancellationToken)
-    {
-        if (refreshSessionStore is null)
-            return null;
-
-        try
-        {
-            return await refreshSessionStore.ResolveUserIdFromAccessTokenAsync(token, cancellationToken);
-        }
-        catch
-        {
-            return null;
-        }
+        var userId = await tokenResolver.ResolveUserIdAsync(req, cancellationToken);
+        return string.IsNullOrWhiteSpace(userId) ? (false, null) : (true, userId);
     }
 
     private static async Task<HttpResponseData> JsonOk<T>(

--- a/PluckIt.Functions/Functions/StylistFunctions.cs
+++ b/PluckIt.Functions/Functions/StylistFunctions.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Text.Json;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using PluckIt.Core;
 using PluckIt.Functions.Auth;
@@ -13,10 +12,8 @@ namespace PluckIt.Functions.Functions;
 public class StylistFunctions(
     IWardrobeRepository repo,
     IStylistService stylist,
-    IConfiguration config,
-    GoogleTokenValidator tokenValidator,
-    ILogger<StylistFunctions> logger,
-    RefreshSessionStore? refreshSessionStore = null)
+    ITokenResolver tokenResolver,
+    ILogger<StylistFunctions> logger)
 {
     [Function(nameof(GetRecommendations))]
     public async Task<HttpResponseData> GetRecommendations(
@@ -93,100 +90,11 @@ public class StylistFunctions(
         HttpRequestData req,
         CancellationToken cancellationToken = default)
     {
-        var path = req.Url.PathAndQuery;
-        if (TryGetBearerToken(req, out var token))
+        var userId = await tokenResolver.ResolveUserIdAsync(req, cancellationToken);
+        if (!string.IsNullOrWhiteSpace(userId))
         {
-            var tokenPrefix = TruncateTokenPrefix(token);
-            var tokenAudience = ReadJwtAudience(token);
-            logger.LogDebug(
-                "StylistFunctions auth attempt: path={Path} aud={Audience} tokenPrefix={TokenPrefix}",
-                path,
-                tokenAudience ?? "unknown",
-                tokenPrefix);
-
-            var sub = await tokenValidator.ValidateAsync(token);
-            if (sub is not null) return (true, sub);
-
-            var sessionUserId = await ResolveUserIdFromSessionTokenAsync(token, cancellationToken);
-            if (!string.IsNullOrWhiteSpace(sessionUserId))
-                return (true, sessionUserId);
-
-            logger.LogWarning(
-                "StylistFunctions auth failed: path={Path} aud={Audience} tokenPrefix={TokenPrefix}",
-                path,
-                tokenAudience ?? "unknown",
-                tokenPrefix);
+            return (true, userId);
         }
-
-        var devId = config["Local:DevUserId"];
-        if (!string.IsNullOrEmpty(devId)) return (true, devId);
-
         return (false, null);
-    }
-
-    private static bool TryGetBearerToken(HttpRequestData req, out string token)
-    {
-        token = string.Empty;
-        if (!req.Headers.TryGetValues("Authorization", out var authHeaders))
-            return false;
-
-        var header = authHeaders.FirstOrDefault();
-        if (string.IsNullOrWhiteSpace(header) || !header.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        token = header["Bearer ".Length..].Trim();
-        return !string.IsNullOrWhiteSpace(token);
-    }
-
-    private async Task<string?> ResolveUserIdFromSessionTokenAsync(string token, CancellationToken cancellationToken)
-    {
-        if (refreshSessionStore is null)
-            return null;
-
-        try
-        {
-            return await refreshSessionStore.ResolveUserIdFromAccessTokenAsync(token, cancellationToken);
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private static string? ReadJwtAudience(string token)
-    {
-        var parts = token.Split('.');
-        if (parts.Length < 2 || string.IsNullOrWhiteSpace(parts[1]))
-            return null;
-
-        try
-        {
-            var payload = Convert.FromBase64String(
-                parts[1]
-                    .Replace('-', '+')
-                    .Replace('_', '/')
-                    .PadRight(parts[1].Length + (4 - parts[1].Length % 4) % 4, '='));
-            using var doc = JsonDocument.Parse(payload);
-            if (!doc.RootElement.TryGetProperty("aud", out var aud))
-                return null;
-
-            return aud.ValueKind == JsonValueKind.String
-                ? aud.GetString()
-                : null;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private static string TruncateTokenPrefix(string token)
-    {
-        const int maxPrefixLength = 20;
-        return string.IsNullOrEmpty(token)
-            ? "<empty>"
-            : token.Length <= maxPrefixLength
-                ? token
-                : $"{token[..maxPrefixLength]}...";
     }
 }

--- a/PluckIt.Functions/Program.cs
+++ b/PluckIt.Functions/Program.cs
@@ -68,6 +68,7 @@ var host = new HostBuilder()
         // IHttpClientFactory is already registered by the AddHttpClient("processor") call below.
         // GoogleTokenValidator is a singleton so the JWKS cache is shared across invocations.
         services.AddSingleton<GoogleTokenValidator>();
+        services.AddSingleton<ITokenResolver, TokenResolver>();
         services.AddSingleton(sp =>
             new WardrobeFunctionsAuthContext(
                 config["Local:DevUserId"],

--- a/PluckIt.Tests/Unit/Auth/TokenResolverTests.cs
+++ b/PluckIt.Tests/Unit/Auth/TokenResolverTests.cs
@@ -1,0 +1,79 @@
+using Shouldly;
+using PluckIt.Functions.Auth;
+using PluckIt.Tests.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace PluckIt.Tests.Unit.Auth;
+
+/// <summary>Unit tests for <see cref="TokenResolver"/>.</summary>
+[Trait("Category", "Unit")]
+public sealed class TokenResolverTests
+{
+    [Fact]
+    public async Task ResolveUserIdAsync_ReturnsLocalDevUser_WhenAuthorizationHeaderMissing()
+    {
+        var resolver = new TokenResolver(
+            validateTokenAsync: _ => Task.FromResult<string?>(null),
+            resolveSessionUserIdAsync: null,
+            localDevUserId: "dev-user-1",
+            NullLogger<TokenResolver>.Instance);
+
+        var request = TestRequest.Get("http://localhost/api/test");
+
+        var userId = await resolver.ResolveUserIdAsync(request, CancellationToken.None);
+
+        userId.ShouldBe("dev-user-1");
+    }
+
+    [Fact]
+    public async Task ResolveUserIdAsync_ReturnsGoogleUserId_WhenValidationSucceeds()
+    {
+        var resolver = new TokenResolver(
+            validateTokenAsync: _ => Task.FromResult<string?>("google-user-1"),
+            resolveSessionUserIdAsync: null,
+            localDevUserId: "dev-user-1",
+            NullLogger<TokenResolver>.Instance);
+
+        var request = TestRequest.Get("http://localhost/api/test");
+        request.Headers.Add("Authorization", "Bearer token-abc");
+
+        var userId = await resolver.ResolveUserIdAsync(request, CancellationToken.None);
+
+        userId.ShouldBe("google-user-1");
+    }
+
+    [Fact]
+    public async Task ResolveUserIdAsync_FallsBackToSession_WhenValidationFails()
+    {
+        var resolver = new TokenResolver(
+            validateTokenAsync: _ => Task.FromResult<string?>(null),
+            resolveSessionUserIdAsync: (_, _ct) => Task.FromResult<string?>("session-user-1"),
+            localDevUserId: "dev-user-1",
+            NullLogger<TokenResolver>.Instance);
+
+        var request = TestRequest.Get("http://localhost/api/test");
+        request.Headers.Add("Authorization", "Bearer token-abc");
+
+        var userId = await resolver.ResolveUserIdAsync(request, CancellationToken.None);
+
+        userId.ShouldBe("session-user-1");
+    }
+
+    [Fact]
+    public async Task ResolveUserIdAsync_ReturnsNull_WhenValidationAndSessionFail()
+    {
+        var resolver = new TokenResolver(
+            validateTokenAsync: _ => Task.FromResult<string?>(null),
+            resolveSessionUserIdAsync: (_, _ct) => Task.FromResult<string?>(null),
+            localDevUserId: null,
+            NullLogger<TokenResolver>.Instance);
+
+        var request = TestRequest.Get("http://localhost/api/test");
+        request.Headers.Add("Authorization", "Bearer token-abc");
+
+        var userId = await resolver.ResolveUserIdAsync(request, CancellationToken.None);
+
+        userId.ShouldBeNull();
+    }
+}

--- a/PluckIt.Tests/Unit/Functions/CollectionFunctionsTests.cs
+++ b/PluckIt.Tests/Unit/Functions/CollectionFunctionsTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text.Json;
 using Shouldly;
 using PluckIt.Core;
+using PluckIt.Functions.Auth;
 using PluckIt.Functions.Functions;
 using PluckIt.Functions.Serialization;
 using PluckIt.Tests.Fakes;
@@ -36,11 +37,9 @@ public sealed class CollectionFunctionsTests
 
     private static CollectionFunctions CreateSut(InMemoryCollectionRepository? repo = null, string userId = OwnerId)
     {
-        var cfg = TestConfiguration.WithDevUser(userId);
         return new CollectionFunctions(
             repo ?? new InMemoryCollectionRepository(),
-            TestFactory.CreateTokenValidator(cfg),
-            cfg);
+            new TestTokenResolver(userId));
     }
 
     // ── GetCollections ───────────────────────────────────────────────────────
@@ -82,11 +81,9 @@ public sealed class CollectionFunctionsTests
     [Fact]
     public async Task GetCollections_Returns401WhenUnauthenticated()
     {
-        var cfg = TestConfiguration.Unauthenticated();
         var sut = new CollectionFunctions(
             new InMemoryCollectionRepository(),
-            TestFactory.CreateTokenValidator(cfg),
-            cfg);
+            new TestTokenResolver(null));
 
         var result = await sut.GetCollections(
             TestRequest.Get("http://localhost/api/collections"), CancellationToken.None);
@@ -227,5 +224,15 @@ public sealed class CollectionFunctionsTests
 
         result.StatusCode.ShouldBe(HttpStatusCode.NoContent);
         repo.AllCollections[0].ClothingItemIds.ShouldNotContain("item-xyz");
+    }
+
+    private sealed class TestTokenResolver(string? userId) : ITokenResolver
+    {
+        public Task<string?> ResolveUserIdAsync(
+            Microsoft.Azure.Functions.Worker.Http.HttpRequestData request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult<string?>(userId);
+        }
     }
 }

--- a/PluckIt.Tests/Unit/Functions/StylistFunctionsTests.cs
+++ b/PluckIt.Tests/Unit/Functions/StylistFunctionsTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System;
 using Shouldly;
 using PluckIt.Core;
+using PluckIt.Functions.Auth;
 using PluckIt.Functions.Functions;
 using PluckIt.Tests.Fakes;
 using PluckIt.Tests.Helpers;
@@ -28,12 +29,10 @@ public sealed class StylistFunctionsTests
         InMemoryWardrobeRepository? repo    = null,
         FakeStylistService?         stylist = null)
     {
-        var cfg = TestConfiguration.WithDevUser(UserId);
         return new StylistFunctions(
             repo    ?? new InMemoryWardrobeRepository(),
             stylist ?? new FakeStylistService(),
-            cfg,
-            TestFactory.CreateTokenValidator(cfg),
+            new TestTokenResolver(UserId),
             TestFactory.NullLogger<StylistFunctions>());
     }
 
@@ -66,12 +65,10 @@ public sealed class StylistFunctionsTests
     [Fact]
     public async Task GetRecommendations_Returns401WhenUnauthenticated()
     {
-        var cfg = TestConfiguration.Unauthenticated();
         var sut = new StylistFunctions(
             new InMemoryWardrobeRepository(),
             new FakeStylistService(),
-            cfg,
-            TestFactory.CreateTokenValidator(cfg),
+            new TestTokenResolver(null),
             TestFactory.NullLogger<StylistFunctions>());
 
         var result = await sut.GetRecommendations(
@@ -133,5 +130,15 @@ public sealed class StylistFunctionsTests
         stylist.LastWardrobe!.Count.ShouldBe(1);
         stylist.LastWardrobe![0].Category.ShouldBe("Tops");
         stylist.LastWardrobe![0].WearCount.ShouldBeGreaterThanOrEqualTo(2);
+    }
+
+    private sealed class TestTokenResolver(string? userId) : ITokenResolver
+    {
+        public Task<string?> ResolveUserIdAsync(
+            Microsoft.Azure.Functions.Worker.Http.HttpRequestData request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult<string?>(userId);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Introduced `ITokenResolver` and `TokenResolver` to centralize bearer/auth/session identity resolution across `AuthFunctions`, `CollectionFunctions`, and `StylistFunctions`.
- Updated DI registration in `PluckIt.Functions/Program.cs` to share the resolver as a singleton service.
- Removed duplicated token parsing/validation helpers from functions and replaced them with calls to `TokenResolver.ResolveUserIdAsync`.
- Added `TokenResolver` unit tests covering local-dev fallback, Google-ID-token resolution, session fallback, and null-result behavior.
- Updated `CollectionFunctions` and `StylistFunctions` tests to inject `ITokenResolver` directly.
- Updated dotnet function docs in the wiki for shared auth behavior.

## Validation
- `dotnet build PluckIt.Functions/PluckIt.Functions.csproj`
- `dotnet test PluckIt.Tests/PluckIt.Tests.csproj --filter "FullyQualifiedName~CollectionFunctionsTests|FullyQualifiedName~StylistFunctionsTests|FullyQualifiedName~TokenResolverTests"`

## Issue
- https://github.com/AB-Law/Pluck-It/issues/100
